### PR TITLE
Resizes images if Imagick extension is missing

### DIFF
--- a/app/Photo.php
+++ b/app/Photo.php
@@ -550,6 +550,8 @@ class Photo extends Model
             $medium->clear();
             $medium->destroy();
 
+        } else {
+            $error = true;
         }
 
         if($error)


### PR DESCRIPTION
If the Imagick extension isn't installed `$error = false` and the backup
GD resizing doesn't get run. `Photo::createMedium` still returns true so
the medium (and small) flags get set in the DB.