### PR TITLE
Bugfix for Index length error on `artisan migrate`

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -51,7 +51,7 @@ return [
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',
             'strict' => true,
-            'engine' => null,
+            'engine' => 'InnoDB ROW_FORMAT=DYNAMIC',
         ],
 
         'pgsql' => [


### PR DESCRIPTION
The `migrate` script can throw an error that a table column index
is too long when set to `varchar(255)`:

**Laravel error log entry**
```text
local.ERROR: SQLSTATE[HY000]: General error: 1709 Index column size too large. The maximum column size is 767 bytes. (SQL: alter table `users` add unique `users_username_unique`(`username`))
```

Setting the `DYNAMIC` flag on
the Laravel engine fixes the issue.

See https://stackoverflow.com/questions/23786359/laravel-migration-unique-key-is-too-long-even-if-specified/39750202#39750202
for more details.