### PR TITLE
Fixes #22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,11 @@
         ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover"
+            "@php artisan package:discover",
+            "@make_user_css"
+        ],
+        "make_user_css": [
+            "touch public/dist/user.css"
         ]
     },
     "config": {


### PR DESCRIPTION
Added a script in composer after the install dump to make a user.css
file in the `dist` directory to prevent console or UI errors.

I haven't worked with composer scripts at all, which is why I'm doing this as a PR rather than a straight commit. It worked fine on my local machine when testing.