### PR TITLE
Use BigInteger instead of simple integer for ids.

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -37,8 +37,9 @@ class PhotoController extends Controller
 	function get(Request $request)
 	{
 		$request->validate([
-			'albumID' => 'string|required',
 			// we actually don't care about that one...
+			'albumID' => 'string|required',
+
 			'photoID' => 'string|required'
 		]);
 

--- a/app/ModelFunctions/Helpers.php
+++ b/app/ModelFunctions/Helpers.php
@@ -52,15 +52,14 @@ class Helpers
 	{
 
 		// Generate id based on the current microtime
-		$id = str_replace('.', '', microtime(true));
-		$id = substr($id, -10);
+		$id = str_replace(' ', '', microtime(true));
+		$id = str_replace('.', '', $id);
 
 		// Ensure that the id has a length of 10 chars
-		while (strlen($id) < 10) {
+		while (strlen($id) < 14) {
 			$id = '0'.$id;
 		}
 
-		$id[0] = strval(intval($id[0]) % 4);
 		// Return id as a string. Don't convert the id to an integer
 		// as 14 digits are too big for 32bit PHP versions.
 		return $id;

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -788,9 +788,13 @@ class PhotoFunctions
 
 				return $this->save($photo, $albumID);
 			}
+			else if ($errorCode == 1264) {
+				Logs::error(__METHOD__, __LINE__, 'Id is a bit too big... '.$photo->id);
+				return Response::error('Id is a bit too big... '.$photo->id);
+			}
 			else {
 				Logs::error(__METHOD__, __LINE__, 'Something went wrong, error '.$errorCode);
-				return 'false';
+				return Response::error('Something went wrong, error'.$errorCode);
 			}
 		}
 
@@ -799,7 +803,7 @@ class PhotoFunctions
 			$album = Album::find($albumID);
 			if ($album === null) {
 				Logs::error(__METHOD__, __LINE__, 'Could not find specified album');
-				return 'false';
+				return Response::error('Could not find specified album');
 			}
 			$album->update_min_max_takestamp();
 			if (!$album->save()) {

--- a/database/migrations/2018_08_03_110935_create_albums_table.php
+++ b/database/migrations/2018_08_03_110935_create_albums_table.php
@@ -34,7 +34,7 @@ class CreateAlbumsTable extends Migration
 			    $table->bigIncrements('id');
 			    $table->char('title', 100)->default('');
 			    $table->integer('owner_id')->default(0);
-			    $table->bigInteger('parent_id')->unsigned()->nullable();
+			    $table->bigInteger('parent_id')->unsigned()->nullable()->default(null)->index();
 			    $table->foreign('parent_id')->references('id')->on('albums');
 			    $table->text('description');
 			    $table->timestamp('min_takestamp')->nullable();

--- a/database/migrations/2018_08_03_110935_create_albums_table.php
+++ b/database/migrations/2018_08_03_110935_create_albums_table.php
@@ -31,10 +31,10 @@ class CreateAlbumsTable extends Migration
 	    if(!Schema::hasTable('albums')) {
 //        Schema::dropIfExists('albums');
 		    Schema::create('albums', function (Blueprint $table) {
-			    $table->increments('id');
+			    $table->bigIncrements('id');
 			    $table->char('title', 100)->default('');
 			    $table->integer('owner_id')->default(0);
-			    $table->integer('parent_id')->unsigned()->nullable();
+			    $table->bigInteger('parent_id')->unsigned()->nullable();
 			    $table->foreign('parent_id')->references('id')->on('albums');
 			    $table->text('description');
 			    $table->timestamp('min_takestamp')->nullable();

--- a/database/migrations/2018_08_03_110936_create_photos_table.php
+++ b/database/migrations/2018_08_03_110936_create_photos_table.php
@@ -46,7 +46,7 @@ class CreatePhotosTable extends Migration
 	    if(!Schema::hasTable('photos')) {
 //        Schema::dropIfExists('photos');
 		    Schema::create('photos', function (Blueprint $table) {
-			    $table->Increments('id');
+			    $table->bigIncrements('id');
 			    $table->char('title', 100);
 			    $table->text('description')->nullable();
 			    $table->char('url', 100);
@@ -70,7 +70,7 @@ class CreatePhotosTable extends Migration
 			    $table->timestamp('takestamp')->nullable();
 			    $table->boolean('star')->default(false);
 			    $table->char('thumbUrl', 37)->default('');
-			    $table->integer('album_id')->unsigned()->nullable()->default(null);
+			    $table->bigInteger('album_id')->unsigned()->nullable()->default(null);
 			    $table->foreign('album_id')->references('id')->on('albums')->onDelete('cascade');
 			    $table->char('checksum', 40)->default('');
 			    $table->boolean('medium')->default(false);

--- a/database/migrations/2018_08_03_110936_create_photos_table.php
+++ b/database/migrations/2018_08_03_110936_create_photos_table.php
@@ -70,7 +70,7 @@ class CreatePhotosTable extends Migration
 			    $table->timestamp('takestamp')->nullable();
 			    $table->boolean('star')->default(false);
 			    $table->char('thumbUrl', 37)->default('');
-			    $table->bigInteger('album_id')->unsigned()->nullable()->default(null);
+			    $table->bigInteger('album_id')->unsigned()->nullable()->default(null)->index();
 			    $table->foreign('album_id')->references('id')->on('albums')->onDelete('cascade');
 			    $table->char('checksum', 40)->default('');
 			    $table->boolean('medium')->default(false);

--- a/database/migrations/2018_08_03_111324_create_logs_table.php
+++ b/database/migrations/2018_08_03_111324_create_logs_table.php
@@ -29,7 +29,7 @@ class CreateLogsTable extends Migration
 	    if(!Schema::hasTable('logs')) {
 //        Schema::dropIfExists('logs');
 		    Schema::create('logs', function (Blueprint $table) {
-			    $table->increments('id');
+			    $table->bigIncrements('id');
 			    $table->char('type', 11);
 			    $table->char('function', 100);
 			    $table->integer('line');

--- a/database/migrations/2018_08_15_102039_move_albums.php
+++ b/database/migrations/2018_08_15_102039_move_albums.php
@@ -19,11 +19,11 @@ class MoveAlbums extends Migration
 		    if (Schema::hasTable(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_albums')) {
 			    $results = DB::table(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_albums')->select('*')->get();
 			    foreach ($results as $result) {
-				    $id = $result->id;
-				    $id = substr($id, 1, 10);
-				    $id[0] = strval(intval($id[0]) % 4);
+//				    $id = $result->id;
+//				    $id = substr($id, 1, 10);
+//				    $id[0] = strval(intval($id[0]) % 4);
 				    $album = new Album();
-				    $album->id = $id;
+				    $album->id = $result->id;
 				    $album->title = $result->title;
 				    $album->description = $result->description;
 				    $album->public = $result->public;

--- a/database/migrations/2018_08_15_102039_move_albums.php
+++ b/database/migrations/2018_08_15_102039_move_albums.php
@@ -19,9 +19,6 @@ class MoveAlbums extends Migration
 		    if (Schema::hasTable(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_albums')) {
 			    $results = DB::table(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_albums')->select('*')->get();
 			    foreach ($results as $result) {
-//				    $id = $result->id;
-//				    $id = substr($id, 1, 10);
-//				    $id[0] = strval(intval($id[0]) % 4);
 				    $album = new Album();
 				    $album->id = $result->id;
 				    $album->title = $result->title;

--- a/database/migrations/2018_08_15_103716_move_photos.php
+++ b/database/migrations/2018_08_15_103716_move_photos.php
@@ -22,14 +22,6 @@ class MovePhotos extends Migration
 			if (Schema::hasTable(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_photos')) {
 				$results = DB::table(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_photos')->select('*')->get();
 				foreach ($results as $result) {
-//					$id = $result->id;
-//					$id = substr($id, 1, 10);
-//					$id[0] = strval(intval($id[0]) % 4);
-//
-//					$album = $result->album;
-//					$album = substr($album, 1, 10);
-//					$album[0] = strval(intval($album[0]) % 4);
-
 					$photo = new Photo();
 					$photo->id = $result->id;
 					$photo->title = $result->title;

--- a/database/migrations/2018_08_15_103716_move_photos.php
+++ b/database/migrations/2018_08_15_103716_move_photos.php
@@ -22,16 +22,16 @@ class MovePhotos extends Migration
 			if (Schema::hasTable(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_photos')) {
 				$results = DB::table(env('DB_OLD_LYCHEE_PREFIX', '') . 'lychee_photos')->select('*')->get();
 				foreach ($results as $result) {
-					$id = $result->id;
-					$id = substr($id, 1, 10);
-					$id[0] = strval(intval($id[0]) % 4);
-
-					$album = $result->album;
-					$album = substr($album, 1, 10);
-					$album[0] = strval(intval($album[0]) % 4);
+//					$id = $result->id;
+//					$id = substr($id, 1, 10);
+//					$id[0] = strval(intval($id[0]) % 4);
+//
+//					$album = $result->album;
+//					$album = substr($album, 1, 10);
+//					$album[0] = strval(intval($album[0]) % 4);
 
 					$photo = new Photo();
-					$photo->id = $id;
+					$photo->id = $result->id;
 					$photo->title = $result->title;
 					$photo->description = $result->description;
 					$photo->url = $result->url;
@@ -51,7 +51,7 @@ class MovePhotos extends Migration
 					$photo->takestamp = ($result->takestamp == 0 || $result->takestamp == null) ? null : date("Y-m-d H:i:s", $result->takestamp);
 					$photo->star = $result->star;
 					$photo->thumbUrl = $result->thumbUrl;
-					$photo->album_id = $album;
+					$photo->album_id = $result->album;
 					$photo->checksum = $result->checksum;
 					$photo->medium = $result->medium;
 					$photo->small = $result->small;

--- a/database/migrations/2018_10_30_135411_sharing.php
+++ b/database/migrations/2018_10_30_135411_sharing.php
@@ -15,10 +15,10 @@ class Sharing extends Migration
     {
         Schema::dropIfExists('user_album');
         Schema::create('user_album', function (Blueprint $table) {
-            $table->increments('id');
-            $table->integer('album_id')->unsigned()->index();
+            $table->bigIncrements('id');
+            $table->bigInteger('album_id')->unsigned()->index();
             $table->foreign('album_id')->references('id')->on('albums')->onDelete('cascade');
-            $table->integer('user_id')->unsigned()->index();
+            $table->bigInteger('user_id')->unsigned()->index();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }

--- a/database/migrations/2018_10_30_135411_sharing.php
+++ b/database/migrations/2018_10_30_135411_sharing.php
@@ -16,7 +16,7 @@ class Sharing extends Migration
         Schema::dropIfExists('user_album');
         Schema::create('user_album', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->bigInteger('album_id')->unsigned()->index();
+	        $table->bigInteger('album_id')->unsigned()->nullable()->default(null)->index();
             $table->foreign('album_id')->references('id')->on('albums')->onDelete('cascade');
             $table->integer('user_id')->unsigned()->index();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');

--- a/database/migrations/2018_10_30_135411_sharing.php
+++ b/database/migrations/2018_10_30_135411_sharing.php
@@ -18,7 +18,7 @@ class Sharing extends Migration
             $table->bigIncrements('id');
             $table->bigInteger('album_id')->unsigned()->index();
             $table->foreign('album_id')->references('id')->on('albums')->onDelete('cascade');
-            $table->bigInteger('user_id')->unsigned()->index();
+            $table->integer('user_id')->unsigned()->index();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
         });
     }

--- a/database/migrations/2019_02_03_133007_change_id_type.php
+++ b/database/migrations/2019_02_03_133007_change_id_type.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Album;
+use App\Photo;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeIdType extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+    	// create copy to back up the data
+		Schema::table('user_album', function (Blueprint $table) {
+			$table->bigInteger('album_id_save')->unsigned()->nullable()->default(null)->after('album_id');
+		});
+	    Schema::table('photos', function (Blueprint $table) {
+		    $table->bigInteger('album_id_save')->unsigned()->nullable()->default(null)->index()->after('album_id');
+	    });
+	    Schema::table('albums', function (Blueprint $table) {
+		    $table->bigInteger('parent_id_save')->unsigned()->nullable()->default(null)->after('parent_id');
+	    });
+
+
+	    // copy
+	    Photo::where('album_id_save',null)->update([
+			    "album_id_save" => DB::raw("`album_id`"),
+	    ]);
+	    Album::where('parent_id_save',null)->update([
+		    "parent_id_save" => DB::raw("`parent_id`"),
+	    ]);
+		DB::table('user_album')->where('album_id_save',null)->update([
+			"album_id_save" => DB::raw("`album_id`"),
+		]);
+
+	    Schema::table('user_album', function (Blueprint $table) {
+		    $table->dropForeign(['album_id']);
+		    $table->dropColumn('album_id');
+	    });
+	    Schema::table('photos', function (Blueprint $table) {
+		    $table->dropForeign(['album_id']);
+		    $table->dropColumn('album_id');
+	    });
+	    Schema::table('albums', function (Blueprint $table) {
+		    $table->dropForeign(['parent_id']);
+		    $table->dropColumn('parent_id');
+	    });
+
+	    Schema::table('albums', function (Blueprint $table) {
+		    $table->bigIncrements('id')->change();
+		    $table->bigInteger('parent_id')->unsigned()->nullable()->default(null)->index()->after('parent_id_save');
+	    });
+	    Schema::table('albums', function (Blueprint $table) {
+		    $table->foreign('parent_id')->references('id')->on('albums');
+	    });
+
+	    Schema::table('user_album', function (Blueprint $table) {
+		    $table->bigInteger('album_id')->unsigned()->nullable()->default(null)->index()->after('album_id_save');
+		    $table->foreign('album_id')->references('id')->on('albums')->onDelete('cascade');
+	    });
+	    Schema::table('photos', function (Blueprint $table) {
+		    $table->bigInteger('album_id')->unsigned()->nullable()->default(null)->index()->after('album_id_save');
+		    $table->foreign('album_id')->references('id')->on('albums')->onDelete('cascade');
+	    });
+
+	    // copy
+	    Photo::where('album_id',null)->update([
+		    "album_id" => DB::raw("`album_id_save`"),
+	    ]);
+	    Album::where('parent_id',null)->update([
+		    "parent_id" => DB::raw("`parent_id_save`"),
+	    ]);
+	    DB::table('user_album')->where('album_id',null)->update([
+		    "album_id" => DB::raw("`album_id_save`"),
+	    ]);
+
+	    Schema::table('photos', function (Blueprint $table) {
+		    $table->dropColumn(['album_id_save']);
+	    });
+	    Schema::table('user_album', function (Blueprint $table) {
+		    $table->dropColumn(['album_id_save']);
+	    });
+	    Schema::table('albums', function (Blueprint $table) {
+		    $table->dropColumn(['parent_id_save']);
+	    });
+
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+    	echo "There is no going back for ".__CLASS__."!\n";
+    }
+}

--- a/database/migrations/2019_02_03_133007_change_id_type.php
+++ b/database/migrations/2019_02_03_133007_change_id_type.php
@@ -90,6 +90,10 @@ class ChangeIdType extends Migration
 		    $table->dropColumn(['parent_id_save']);
 	    });
 
+	    Schema::table('photos', function (Blueprint $table) {
+		    $table->bigIncrements('id')->change();
+	    });
+
     }
 
 


### PR DESCRIPTION
This should simplify the migration from the v3 to the v4 and reduce the risk of collisions