### PR TITLE
Fixes #75

### DIFF
--- a/database/migrations/2018_08_15_103716_move_photos.php
+++ b/database/migrations/2018_08_15_103716_move_photos.php
@@ -43,7 +43,7 @@ class MovePhotos extends Migration
 					$photo->takestamp = ($result->takestamp == 0 || $result->takestamp == null) ? null : date("Y-m-d H:i:s", $result->takestamp);
 					$photo->star = $result->star;
 					$photo->thumbUrl = $result->thumbUrl;
-					$photo->album_id = $result->album;
+					$photo->album_id = ($result->album == 0) ? null : $result->album_id;
 					$photo->checksum = $result->checksum;
 					$photo->medium = $result->medium;
 					$photo->small = $result->small;

--- a/database/migrations/2018_08_15_103716_move_photos.php
+++ b/database/migrations/2018_08_15_103716_move_photos.php
@@ -43,7 +43,7 @@ class MovePhotos extends Migration
 					$photo->takestamp = ($result->takestamp == 0 || $result->takestamp == null) ? null : date("Y-m-d H:i:s", $result->takestamp);
 					$photo->star = $result->star;
 					$photo->thumbUrl = $result->thumbUrl;
-					$photo->album_id = ($result->album == 0) ? null : $result->album_id;
+					$photo->album_id = ($result->album == 0) ? null : $result->album;
 					$photo->checksum = $result->checksum;
 					$photo->medium = $result->medium;
 					$photo->small = $result->small;


### PR DESCRIPTION
Migrations didn't check for unsorted photos (`album_id = 0`) and would
throw a foreign key error because there was no album ID which matched
when the tables were migrated.

This adds a conditional check to reset a photo with `album_id = 0` to
`null` to prevent migration failure.