### PR TITLE
Server support for full HiDPI

### DIFF
--- a/app/Album.php
+++ b/app/Album.php
@@ -79,12 +79,13 @@ class Album extends Model
 	{
 
 		$return['thumbs'] = array();
+		$return['thumbs2x'] = array();
 		$return['types'] = array();
 
 		$alb = $this->get_all_subalbums();
 		$alb[] = $this->id;
 
-		$thumbs_types = Photo::select('thumbUrl', 'type')
+		$thumbs_types = Photo::select('thumbUrl', 'thumb2x', 'type')
 			->whereIn('album_id', $alb)
 			->orderBy('star', 'DESC')
 			->orderBy(Configs::get_value('sortingPhotos_col'), Configs::get_value('sortingPhotos_order'))
@@ -94,6 +95,14 @@ class Album extends Model
 		$k = 0;
 		foreach ($thumbs_types as $thumb_types) {
 			$return['thumbs'][$k] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumb_types->thumbUrl;
+			if ($thumb_types->thumb2x == '1') {
+				$thumbUrl2x = explode(".", $thumb_types->thumbUrl);
+				$thumbUrl2x = $thumbUrl2x[0].'@2x.'.$thumbUrl2x[1];
+				$return['thumbs2x'][$k] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumbUrl2x;
+			}
+			else {
+				$return['thumbs2x'][$k] = '';
+			}
 			$return['types'][$k] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumb_types->type;
 			$k++;
 		}

--- a/app/Configs.php
+++ b/app/Configs.php
@@ -28,10 +28,13 @@ class Configs extends Model
 		'sortingPhotos_col',
 		'sortingPhotos_order',
 		'default_license',
+		'thumb_2x',
 		'small_max_width',
 		'small_max_height',
+		'small_2x',
 		'medium_max_width',
 		'medium_max_height',
+		'medium_2x',
 	];
 
 

--- a/app/Console/Commands/medium.php
+++ b/app/Console/Commands/medium.php
@@ -64,7 +64,7 @@ class medium extends Command
 				$photo,
 				intval(Configs::get_value('medium_max_width')),
 				intval(Configs::get_value('medium_max_height')),
-				$resWidth, $resHeight)
+				$resWidth, $resHeight, false, 'MEDIUM')
 			) {
 				$photo->medium = $resWidth . 'x' . $resHeight;
 				$photo->save();

--- a/app/Console/Commands/medium.php
+++ b/app/Console/Commands/medium.php
@@ -53,7 +53,7 @@ class medium extends Command
 		$timeout = $this->argument('tm');
 		set_time_limit($timeout);
 
-		$photos = Photo::where('medium', '=', 0)->limit($argument)->get();
+		$photos = Photo::where('medium', '=', '')->limit($argument)->get();
 		if (count($photos) == 0) {
 			$this->line('No pictures requires medium.');
 			return false;
@@ -63,9 +63,10 @@ class medium extends Command
 			if ($this->photoFunctions->createMedium(
 				$photo,
 				intval(Configs::get_value('medium_max_width')),
-				intval(Configs::get_value('medium_max_height')))
+				intval(Configs::get_value('medium_max_height')),
+				$resWidth, $resHeight)
 			) {
-				$photo->medium = 1;
+				$photo->medium = $resWidth . 'x' . $resHeight;
 				$photo->save();
 				$this->line('medium for '.$photo->title.' created.');
 			} else {

--- a/app/Console/Commands/small.php
+++ b/app/Console/Commands/small.php
@@ -53,7 +53,7 @@ class small extends Command
 		$timeout = $this->argument('tm');
 		set_time_limit($timeout);
 
-		$photos = Photo::where('small', '=', 0)->limit($argument)->get();
+		$photos = Photo::where('small', '=', '')->limit($argument)->get();
 		if (count($photos) == 0) {
 			$this->line('No pictures requires small.');
 			return false;
@@ -63,9 +63,10 @@ class small extends Command
 			if ($this->photoFunctions->createMedium(
 				$photo,
 				intval(Configs::get_value('small_max_width')),
-				intval(Configs::get_value('small_max_height')), 'SMALL')
+				intval(Configs::get_value('small_max_height')),
+				$resWidth, $resHeight, 'SMALL')
 			) {
-				$photo->small = 1;
+				$photo->small = $resWidth . 'x' . $resHeight;
 				$photo->save();
 				$this->line('small for '.$photo->title.' created.');
 			}

--- a/app/Console/Commands/small.php
+++ b/app/Console/Commands/small.php
@@ -64,7 +64,7 @@ class small extends Command
 				$photo,
 				intval(Configs::get_value('small_max_width')),
 				intval(Configs::get_value('small_max_height')),
-				$resWidth, $resHeight, 'SMALL')
+				$resWidth, $resHeight, false, 'SMALL')
 			) {
 				$photo->small = $resWidth . 'x' . $resHeight;
 				$photo->save();

--- a/app/Http/Controllers/AlbumsController.php
+++ b/app/Http/Controllers/AlbumsController.php
@@ -119,6 +119,7 @@ class AlbumsController extends Controller
 
 		$return[$kind] = array(
 			'thumbs' => array(),
+			'thumbs2x' => array(),
 			'types'  => array(),
 			'num'    => $photos_sql->count()
 		);
@@ -126,6 +127,14 @@ class AlbumsController extends Controller
 		foreach ($photos as $photo) {
 			if ($i < 3) {
 				$return[$kind]['thumbs'][$i] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$photo->thumbUrl;
+				if ($photo->thumb2x == '1') {
+					$thumbUrl2x = explode(".", $photo->thumbUrl);
+					$thumbUrl2x = $thumbUrl2x[0].'@2x.'.$thumbUrl2x[1];
+					$return[$kind]['thumbs2x'][$i] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumbUrl2x;
+				}
+				else {
+					$return[$kind]['thumbs2x'][$i] = '';
+				}
 				$return[$kind]['types'][$i] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$photo->type;
 				$i++;
 			}
@@ -156,25 +165,25 @@ class AlbumsController extends Controller
 		/**
 		 * Unsorted
 		 */
-		$photos_sql = Photo::select_unsorted(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl', 'type'))->limit(3);
+		$photos_sql = Photo::select_unsorted(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl', 'thumb2x', 'type'))->limit(3);
 		$return = self::gen_return($return, $photos_sql, 'unsorted');
 
 		/**
 		 * Starred
 		 */
-		$photos_sql = Photo::select_stars(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl', 'type'))->limit(3);
+		$photos_sql = Photo::select_stars(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl', 'thumb2x', 'type'))->limit(3);
 		$return = self::gen_return($return, $photos_sql, 'starred');
 
 		/**
 		 * Public
 		 */
-		$photos_sql = Photo::select_public(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl', 'type'))->limit(3);
+		$photos_sql = Photo::select_public(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl', 'thumb2x', 'type'))->limit(3);
 		$return = self::gen_return($return, $photos_sql, 'public');
 
 		/**
 		 * Recent
 		 */
-		$photos_sql = Photo::select_recent(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl'))->limit(3);
+		$photos_sql = Photo::select_recent(Photo::OwnedBy(Session::get('UserID'))->select('thumbUrl', 'thumb2x', 'type'))->limit(3);
 		$return = self::gen_return($return, $photos_sql, 'recent');
 
 		// Return SmartAlbums

--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -84,7 +84,7 @@ class PhotoController extends Controller
 
 		$return = array();
 		$return['thumb'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$photo->thumbUrl;
-		if ($photo->medium == '1') {
+		if ($photo->medium != '') {
 			$return['url'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_MEDIUM').$photo->url;
 		}
 		else {
@@ -390,10 +390,13 @@ class PhotoController extends Controller
 			$duplicate->takestamp = $photo->takestamp;
 			$duplicate->star = $photo->star;
 			$duplicate->thumbUrl = $photo->thumbUrl;
+			$duplicate->thumb2x = $photo->thumb2x;
 			$duplicate->album_id = $photo->album_id;
 			$duplicate->checksum = $photo->checksum;
 			$duplicate->medium = $photo->medium;
+			$duplicate->medium2x = $photo->medium2x;
 			$duplicate->small = $photo->small;
+			$duplicate->small2x = $photo->small2x;
 			$duplicate->owner_id = $photo->owner_id;
 			$no_error &= $duplicate->save();
 		}

--- a/app/Image/GdHandler.php
+++ b/app/Image/GdHandler.php
@@ -28,7 +28,9 @@ class GdHandler implements ImageHandlerInterface
 		string $source,
 		string $destination,
 		int $newWidth,
-		int $newHeight
+		int $newHeight,
+		int &$resWidth,
+		int &$resHeight
 	) : bool {
 		list($width, $height, $mime) = getimagesize($source);
 
@@ -56,6 +58,9 @@ class GdHandler implements ImageHandlerInterface
 
 		imagedestroy($image);
 		imagedestroy($sourceImg);
+
+		$resWidth = $newWidth;
+		$resHeight = $newHeight;
 
 		return true;
 	}

--- a/app/Image/ImageHandlerInterface.php
+++ b/app/Image/ImageHandlerInterface.php
@@ -19,7 +19,9 @@ interface ImageHandlerInterface
 		string $source,
 		string $destination,
 		int $newWidth,
-		int $newHeight
+		int $newHeight,
+		int &$resWidth,
+		int &$resHeight
 	) : bool ;
 
 		/**

--- a/app/Image/ImagickHandler.php
+++ b/app/Image/ImagickHandler.php
@@ -29,7 +29,9 @@ class ImagickHandler implements ImageHandlerInterface
 		string $source,
 		string $destination,
 		int $newWidth,
-		int $newHeight
+		int $newHeight,
+		int &$resWidth,
+		int &$resHeight
 	): bool
 	{
 		try {
@@ -45,6 +47,8 @@ class ImagickHandler implements ImageHandlerInterface
 			$image->scaleImage($newWidth, $newHeight, ($newWidth != 0));
 			$image->writeImage($destination);
 			Logs::notice(__METHOD__, __LINE__, 'Saving thumb to '.$destination);
+			$resWidth = $image->getImageWidth();
+			$resHeight = $image->getImageHeight();
 			$image->clear();
 			$image->destroy();
 		}

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -149,6 +149,9 @@ class PhotoFunctions
 	 * @param Photo $photo
 	 * @param int $newWidth
 	 * @param int $newHeight
+	 * @param $resWidth
+	 * @param $resHeight
+	 * @param bool $x2
 	 * @param string $kind
 	 * @return boolean Returns true when successful.
 	 */

--- a/app/Photo.php
+++ b/app/Photo.php
@@ -131,22 +131,58 @@ class Photo extends Model
 		}
 
 		// Parse medium
-		if ($this->medium == '1') {
+		if ($this->medium != '') {
 			$photo['medium'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_MEDIUM').$this->url;
+			$photo['medium_dim'] = $this->medium;
 		}
 		else {
 			$photo['medium'] = '';
+			$photo['medium_dim'] = '';
 		}
 
-		if ($this->small == '1') {
+		if ($this->medium2x != '') {
+			$url2x = explode('.', $this->url);
+			$url2x = $url2x[0].'@2x.'.$url2x[1];
+			$photo['medium2x'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_MEDIUM').$url2x;
+			$photo['medium2x_dim'] = $this->medium2x;
+		}
+		else {
+			$photo['medium2x'] = '';
+			$photo['medium2x_dim'] = '';
+		}
+
+		if ($this->small != '') {
 			$photo['small'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_SMALL').$this->url;
+			$photo['small_dim'] = $this->small;
 		}
 		else {
 			$photo['small'] = '';
+			$photo['small_dim'] = '';
+		}
+
+		if ($this->small2x != '') {
+			$url2x = explode('.', $this->url);
+			$url2x = $url2x[0].'@2x.'.$url2x[1];
+			$photo['small2x'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_SMALL').$url2x;
+			$photo['small2x_dim'] = $this->small2x;
+		}
+		else {
+			$photo['small2x'] = '';
+			$photo['small2x_dim'] = '';
 		}
 
 		// Parse paths
 		$photo['thumbUrl'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$this->thumbUrl;
+
+		if ($this->thumb2x == '1') {
+			$thumbUrl2x = explode(".", $this->thumbUrl);
+			$thumbUrl2x = $thumbUrl2x[0].'@2x.'.$thumbUrl2x[1];
+			$photo['thumb2x'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumbUrl2x;
+		}
+		else {
+			$photo['thumb2x'] = '';
+		}
+
 		$photo['url'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_BIG').$this->url;
 
 		// Use takestamp as sysdate when possible
@@ -207,9 +243,22 @@ class Photo extends Model
 			$error = true;
 		}
 
-		// Delete medium
+		$url2x = explode(".", $this->url);
+		$url2x = $url2x[0].'@2x.'.$url2x[1];
+
+		if (file_exists(Config::get('defines.dirs.LYCHEE_UPLOADS_MEDIUM').$url2x) && !unlink(Config::get('defines.dirs.LYCHEE_UPLOADS_MEDIUM').$url2x)) {
+			Logs::error(__METHOD__, __LINE__, 'Could not delete high-res photo in uploads/medium/');
+			$error = true;
+		}
+
+		// Delete small
 		if (file_exists(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$this->url) && !unlink(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$this->url)) {
 			Logs::error(__METHOD__, __LINE__, 'Could not delete photo in uploads/small/');
+			$error = true;
+		}
+
+		if (file_exists(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$url2x) && !unlink(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$url2x)) {
+			Logs::error(__METHOD__, __LINE__, 'Could not delete high-res photo in uploads/small/');
 			$error = true;
 		}
 

--- a/database/migrations/2019_02_23_222617_add_hidpi.php
+++ b/database/migrations/2019_02_23_222617_add_hidpi.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Configs;
+use App\Photo;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddHidpi extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		if (Schema::hasTable('configs')) {
+
+			DB::table('configs')->insert([
+				['key' => 'thumb_2x', 'value' => '1'],
+				['key' => 'small_2x', 'value' => '0'],
+				['key' => 'medium_2x', 'value' => '0'],
+			]);
+		}
+		else {
+			echo "Table configs does not exists\n";
+		}
+
+		if (Schema::hasTable('photos')) {
+			Schema::table('photos', function (Blueprint $table) {
+				$table->renameColumn('medium', 'medium_old');
+				$table->renameColumn('small', 'small_old');
+			});
+
+			Schema::table('photos', function (Blueprint $table) {
+				$table->char('medium', 20)->default('');
+				$table->char('medium2x', 20)->default('');
+				$table->char('small', 20)->default('');
+				$table->char('small2x', 20)->default('');
+				$table->boolean('thumb2x')->default(true);
+			});
+
+			$photos = Photo::all();
+			foreach ($photos as $photo) {
+				$save = false;
+
+				// Verify that the 2x thumbnail actually exists. We assume
+				// it does but we support the case where it does not.
+				$thumbUrl2x = explode(".", $photo->thumbUrl);
+				$thumbUrl2x = $thumbUrl2x[0].'@2x.'.$thumbUrl2x[1];
+				if (!file_exists(Config::get('defines.dirs.LYCHEE_UPLOADS_THUMB').$thumbUrl2x)) {
+					$photo->thumb2x = 0;
+					$save = true;
+				}
+
+				// Extract the sizes of medium and small
+				if ($photo->medium_old == '1') {
+					list($width, $height) = getimagesize(Config::get('defines.dirs.LYCHEE_UPLOADS_MEDIUM').$photo->url);
+					$photo->medium = $width . 'x' . $height;
+					$save = true;
+				}
+				if ($photo->small_old == '1') {
+					list($width, $height) = getimagesize(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$photo->url);
+					$photo->small = $width . 'x' . $height;
+					$save = true;
+				}
+
+				if ($save) {
+					$photo->save();
+				}
+			}
+
+			Schema::table('photos', function (Blueprint $table) {
+				$table->dropColumn('medium_old');
+				$table->dropColumn('small_old');
+			});
+		}
+		else {
+			echo "Table photos does not exist\n";
+		}
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		if (env('DB_DROP_CLEAR_TABLES_ON_ROLLBACK', false)) {
+			Configs::where('key','=','thumb_2x')->delete();
+			Configs::where('key','=','small_2x')->delete();
+			Configs::where('key','=','medium_2x')->delete();
+
+			Schema::table('photos', function (Blueprint $table) {
+				$table->renameColumn('medium', 'medium_new');
+				$table->renameColumn('small', 'small_new');
+			});
+			Schema::table('photos', function (Blueprint $table) {
+				$table->boolean('medium')->default(true);
+				$table->boolean('small')->default(true);
+			});
+
+			$photos = Photo::all();
+			foreach ($photos as $photo) {
+				$save = false;
+
+				if ($photo->medium_new === '') {
+					$photo->medium = 0;
+					$save = true;
+				}
+				if ($photo->small_new === '') {
+					$photo->small = 0;
+					$save = true;
+				}
+
+				if ($save) {
+					$photo->save();
+				}
+			}
+
+			Schema::table('photos', function (Blueprint $table) {
+				$table->dropColumn('medium_new');
+				$table->dropColumn('medium2x');
+				$table->dropColumn('small_new');
+				$table->dropColumn('small2x');
+				$table->dropColumn('thumb2x');
+			});
+		}
+	}
+}

--- a/public/dist/view.js
+++ b/public/dist/view.js
@@ -720,7 +720,7 @@ header.bind = function () {
 		contextMenu.photoMore(photo.getID(), e);
 	});
 	header.dom('#button_move').on(eventName, function (e) {
-		contextMenu.move([photo.getID()], e);
+		contextMenu.move([photo.getID()], e, photo.setAlbum);
 	});
 	header.dom('.header__hostedwith').on(eventName, function () {
 		window.open(lychee.website);
@@ -823,7 +823,7 @@ header.setMode = function (mode) {
 			header.dom('.header__toolbar--album').addClass('header__toolbar--visible');
 
 			// Hide download button when album empty
-			if (album.json.photos === false) $('#button_archive').hide();else $('#button_archive').show();
+			if (!album.json || album.json.photos === false) $('#button_archive').hide();else $('#button_archive').show();
 
 			// Hide download button when not logged in and album not downloadable
 			if (lychee.publicMode === true && album.json.downloadable === '0') $('#button_archive').hide();
@@ -1371,7 +1371,9 @@ lychee.locale = {
 	'COPY_ALL_TO': 'Copy All to...',
 	'DELETE': 'Delete',
 	'DELETE_ALL': 'Delete All',
-	'DOWNLOAD': 'Download',
+	'DOWNLOAD': 'Download original size',
+	'DOWNLOAD_MEDIUM': 'Download medium size',
+	'DOWNLOAD_SMALL': 'Download small size',
 	'UPLOAD_PHOTO': 'Upload Photo',
 	'IMPORT_LINK': 'Import from Link',
 	'IMPORT_DROPBOX': 'Import from Dropbox',


### PR DESCRIPTION
This merge request addresses https://github.com/LycheeOrg/Lychee/issues/198.

It's a pretty large patch so allow me to provide an overview/motivation for why I coded it the way I did.  I can of course make any modifications you deem necessary to make it acceptable for merging.

Lychee currently supports HiDPI ("retina") for the square thumbnails only, by creating `@2x` files on the server side during image upload and assuming on the frontend side that those files are always present (the `@2x` names are unconditionally used in `srcset` when generating HTML).

To keep things configurable, I added three new options to the `configs` table: `thumb_2x`, `small_2x`, and `medium_2x`.  Only the first one defaults to 1, to mimic the current behavior.  The others need to be set to 1 manually to activate the generation of `@2x` versions of small and medium images.

Depending on the input image size, some of the image variants, especially the medium@2x, may end up not getting generated.  I decided to extend the `photos` table with additional columns `medium2x`, `small2x`, and for the sake of completeness also `thumb2x` to store that info.  The server API needed to be extended to pass the data on 2x variants to the frontend.

In image view mode, as well as in justified album view, the images may not be rendered at their natural resolution but may be resized.  In those cases, passing density value of `2x` in the `srcset` tag would be incorrect. Instead, the best solution is to pass the widths of each image variant (using the `<width>w` syntax in `srcset`) and the expected rendered size in the `sizes` tag.  But we need to know those widths, and they are not readily available in the frontend.  The server knows them when it generates the images, so I changed the `small`/`small2x`/`medium`/`medium2x` columns in the `photos` table to store `<width>x<height>` strings for each variant, or an empty string if that variant is not available.  I kept `thumb2x` as a 0/1 since that has a fixed size of 400x400.  Again, the server API needed to be extended to pass this additional data (in `small_dim`/`medium_dim`/`small2x_dim`/`medium2x_dim` fields).

Given the size of the patch, I have no intention of backporting it to Lychee v3; however, the patched frontend will also work with an unpatched server.

With that lengthy preface out of the way, I can now discuss parts of the patch itself:

`database/migrations/*` verifies for each image that the `thumb2x` variant actually exists and also extracts the sizes of `small`/`medium` variants using GD.

`Image/` handlers were extended to return the width/height of generated images via two arguments passed by reference.  If this syntax is too ugly to tolerate, please recommend an alternative (I've never coded in PHP before).

In `ModelFunctions/PhotoFunctions.php`, I made the generation of the `thumb2x` variant in `createThumb()` conditional on the input image size to match what was already done for `small`/`medium`.  I added the generation of 2x variants to `add()` and `createMedium()`, conditional on the config variables.

There are two areas that I wasn't sure of:

I believe I did the right thing for `Console/Commands/medium.php` and `small.php` but I didn't test because I don't know how to use these things -- any hint?  Also, should I add support for generating 2x variants there?

I wasn't sure what to do about `getRandom()` in `app/Http/Controllers/PhotoController.php` because I couldn't figure out how to get that Frame mode to work.  Though I feel that that API is needlessly restrictive and it shouldn't be the server's job to pick big vs medium variant.  Why not simply return a whole `Photo` object and let the frontend pick whatever it needs out of it -- there's already code for that?
