### PR TITLE
Make the small/medium/2x commands easier to use

### DIFF
--- a/app/Console/Commands/medium.php
+++ b/app/Console/Commands/medium.php
@@ -53,12 +53,15 @@ class medium extends Command
 		$timeout = $this->argument('tm');
 		set_time_limit($timeout);
 
-		$photos = Photo::where('medium', '=', '')->limit($argument)->get();
+		$this->line('Will attempt to generate up to '.$argument.' medium ('.Configs::get_value('medium_max_width').'x'.Configs::get_value('medium_max_height').') images with a timeout of '.$timeout.' seconds...');
+
+		$photos = Photo::where('medium', '=', '')->where('type', 'like', 'image/%')->get();
 		if (count($photos) == 0) {
 			$this->line('No picture requires medium.');
 			return false;
 		}
 
+		$count = 0;
 		foreach ($photos as $photo) {
 			$resWidth = 0;
 			$resHeight = 0;
@@ -70,9 +73,14 @@ class medium extends Command
 			) {
 				$photo->medium = $resWidth . 'x' . $resHeight;
 				$photo->save();
-				$this->line('medium for '.$photo->title.' created.');
+				$this->line('medium ('.$photo->medium.') for '.$photo->title.' created.');
+				$count++;
+				if ($count == $argument) {
+					$this->line('Rerun this command to check for more images.');
+					break;
+				}
 			} else {
-				$this->line('Could not create medium for '.$photo->title.'.');
+				$this->line('Could not create medium for '.$photo->title.' ('.$photo->width.'x'.$photo->height.').');
 			}
 		}
 	}

--- a/app/Console/Commands/medium2x.php
+++ b/app/Console/Commands/medium2x.php
@@ -53,12 +53,15 @@ class medium2x extends Command
 		$timeout = $this->argument('tm');
 		set_time_limit($timeout);
 
-		$photos = Photo::where('medium2x', '=', '')->limit($argument)->get();
+		$this->line('Will attempt to generate up to '.$argument.' medium@2x ('.(Configs::get_value('medium_max_width')*2).'x'.(Configs::get_value('medium_max_height')*2).') images with a timeout of '.$timeout.' seconds...');
+
+		$photos = Photo::where('medium2x', '=', '')->where('type', 'like', 'image/%')->get();
 		if (count($photos) == 0) {
 			$this->line('No picture requires medium@2x.');
 			return false;
 		}
 
+		$count = 0;
 		foreach ($photos as $photo) {
 			$resWidth = 0;
 			$resHeight = 0;
@@ -70,9 +73,14 @@ class medium2x extends Command
 			) {
 				$photo->medium2x = $resWidth . 'x' . $resHeight;
 				$photo->save();
-				$this->line('medium@2x for '.$photo->title.' created.');
+				$this->line('medium@2x ('.$photo->medium2x.') for '.$photo->title.' created.');
+				$count++;
+				if ($count == $argument) {
+					$this->line('Rerun this command to check for more images.');
+					break;
+				}
 			} else {
-				$this->line('Could not create medium@2x for '.$photo->title.'.');
+				$this->line('Could not create medium@2x for '.$photo->title.' ('.$photo->width.'x'.$photo->height.').');
 			}
 		}
 	}

--- a/app/Console/Commands/small.php
+++ b/app/Console/Commands/small.php
@@ -53,12 +53,14 @@ class small extends Command
 		$timeout = $this->argument('tm');
 		set_time_limit($timeout);
 
-		$photos = Photo::where('small', '=', '')->limit($argument)->get();
+		$this->line('Will attempt to generate up to '.$argument.' small ('.Configs::get_value('small_max_width').'x'.Configs::get_value('small_max_height').') images with a timeout of '.$timeout.' seconds...');
+		$photos = Photo::where('small', '=', '')->where('type', 'like', 'image/%')->get();
 		if (count($photos) == 0) {
 			$this->line('No picture requires small.');
 			return false;
 		}
 
+		$count = 0;
 		foreach ($photos as $photo) {
 			$resWidth = 0;
 			$resHeight = 0;
@@ -70,10 +72,15 @@ class small extends Command
 			) {
 				$photo->small = $resWidth . 'x' . $resHeight;
 				$photo->save();
-				$this->line('small for '.$photo->title.' created.');
+				$this->line('small ('.$photo->small.') for '.$photo->title.' created.');
+				$count++;
+				if ($count == $argument) {
+					$this->line('Rerun this command to check for more images.');
+					break;
+				}
 			}
 			else {
-				$this->line('Could not create small for '.$photo->title.'.');
+				$this->line('Could not create small for '.$photo->title.' ('.$photo->width.'x'.$photo->height.').');
 			}
 		}
 	}

--- a/app/Console/Commands/small2x.php
+++ b/app/Console/Commands/small2x.php
@@ -53,12 +53,14 @@ class small2x extends Command
 		$timeout = $this->argument('tm');
 		set_time_limit($timeout);
 
-		$photos = Photo::where('small2x', '=', '')->limit($argument)->get();
+		$this->line('Will attempt to generate up to '.$argument.' small@2x ('.(Configs::get_value('small_max_width')*2).'x'.(Configs::get_value('small_max_height')*2).') images with a timeout of '.$timeout.' seconds...');
+		$photos = Photo::where('small2x', '=', '')->where('type', 'like', 'image/%')->get();
 		if (count($photos) == 0) {
 			$this->line('No picture requires small@2x.');
 			return false;
 		}
 
+		$count = 0;
 		foreach ($photos as $photo) {
 			$resWidth = 0;
 			$resHeight = 0;
@@ -70,10 +72,15 @@ class small2x extends Command
 			) {
 				$photo->small2x = $resWidth . 'x' . $resHeight;
 				$photo->save();
-				$this->line('small@2x for '.$photo->title.' created.');
+				$this->line('small@2x ('.$photo->small2x.') for '.$photo->title.' created.');
+				$count++;
+				if ($count == $argument) {
+					$this->line('Rerun this command to check for more images.');
+					break;
+				}
 			}
 			else {
-				$this->line('Could not create small@2x for '.$photo->title.'.');
+				$this->line('Could not create small@2x for '.$photo->title.' ('.$photo->width.'x'.$photo->height.').');
 			}
 		}
 	}


### PR DESCRIPTION
Provide additional diagnostics on stdout.
Exclude movies from the process.
Only count successful image creations towards the limit.