### PR TITLE
Reapply changes lost in 7e14093

### DIFF
--- a/app/Album.php
+++ b/app/Album.php
@@ -79,12 +79,13 @@ class Album extends Model
 	{
 
 		$return['thumbs'] = array();
+		$return['thumbs2x'] = array();
 		$return['types'] = array();
 
 		$alb = $this->get_all_subalbums();
 		$alb[] = $this->id;
 
-		$thumbs_types = Photo::select('thumbUrl', 'type')
+		$thumbs_types = Photo::select('thumbUrl', 'thumb2x', 'type')
 			->whereIn('album_id', $alb)
 			->orderBy('star', 'DESC')
 			->orderBy(Configs::get_value('sortingPhotos_col'), Configs::get_value('sortingPhotos_order'))
@@ -94,6 +95,14 @@ class Album extends Model
 		$k = 0;
 		foreach ($thumbs_types as $thumb_types) {
 			$return['thumbs'][$k] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumb_types->thumbUrl;
+			if ($thumb_types->thumb2x == '1') {
+				$thumbUrl2x = explode(".", $thumb_types->thumbUrl);
+				$thumbUrl2x = $thumbUrl2x[0].'@2x.'.$thumbUrl2x[1];
+				$return['thumbs2x'][$k] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumbUrl2x;
+			}
+			else {
+				$return['thumbs2x'][$k] = '';
+			}
 			$return['types'][$k] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$thumb_types->type;
 			$k++;
 		}


### PR DESCRIPTION
I noticed some strange misbehavior with HiDPI images. On investigation I found a minor bug in the front end (I will submit a separate commit for that) but also a major issue on the server side: changes to `App/Album.php` from commit 0a43348 got lost. @ildyria, this appears to have happened during your commit 7e14093.
This PR reapplies the lost changes.