### PR TITLE
Add HiDPI support to Frame mode

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -82,14 +82,7 @@ class PhotoController extends Controller
 			return Response::error('no pictures found!');
 		}
 
-		$return = array();
-		$return['thumb'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_THUMB').$photo->thumbUrl;
-		if ($photo->medium != '') {
-			$return['url'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_MEDIUM').$photo->url;
-		}
-		else {
-			$return['url'] = Config::get('defines.urls.LYCHEE_URL_UPLOADS_BIG').$photo->url;
-		}
+		$return = $photo->prepareData();
 
 		return $return;
 	}


### PR DESCRIPTION
This is a pretty trivial patch needed to add HiDPI support to the Frame mode. The bulk of it will be in a separate PR for the front end.

The front end needs more info about the image to fill in the `srcset` and `sizes` tags; the easiest way to accomplish that is to simply return the whole Photo object which contains everything we may possibly need, and we already have the code to pass it.