### PR TITLE
Always create thumbs/thumbs2x/types for albums

### DIFF
--- a/app/Album.php
+++ b/app/Album.php
@@ -64,6 +64,10 @@ class Album extends Model
 
 		$album['owner'] = $this->owner->username;
 
+		$album['thumbs'] = array();
+		$album['thumbs2x'] = array();
+		$album['types'] = array();
+
 		return $album;
 	}
 
@@ -71,10 +75,6 @@ class Album extends Model
 
 	public function gen_thumbs($return)
 	{
-
-		$return['thumbs'] = array();
-		$return['thumbs2x'] = array();
-		$return['types'] = array();
 
 		$alb = $this->get_all_subalbums();
 		$alb[] = $this->id;


### PR DESCRIPTION
When there's a public, but password-protected album, when listing albums without being logged in, the front end generates an error in `albums.parse` because `albums.thumbs` is undefined. No albums are displayed as a result. It works fine with Lychee v3 though. This patch ensures that we always generate the `thumbs`/`thumbs2x`/`types` arrays in our response to the front end, even if they end up being empty.