### PR TITLE
Don't return thumbs of password-protected subalbums

### DIFF
--- a/app/Album.php
+++ b/app/Album.php
@@ -5,6 +5,7 @@ namespace App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Session;
 
 class Album extends Model
 {
@@ -121,7 +122,9 @@ class Album extends Model
 
 				$album = $subAlbum->prepareData();
 				$album['albums'] = $subAlbum->get_albums($userId);
-				$album = $subAlbum->gen_thumbs($album);
+				if ($subAlbum->password === null || Session::get('login')) {
+					$album = $subAlbum->gen_thumbs($album);
+				}
 
 				$subAlbums[] = $album;
 			}


### PR DESCRIPTION
Server-side fix for #139

This basically duplicates the condition from `AlbumFunctions::prepare_albums()`, only this time for subalbums, and in a less round-about way :smirk: