### PR TITLE
Don't crash when photos are missing

### DIFF
--- a/database/migrations/2019_02_23_222617_add_hidpi.php
+++ b/database/migrations/2019_02_23_222617_add_hidpi.php
@@ -17,41 +17,45 @@ class AddHidpi extends Migration
 	 */
 	public function up()
 	{
-		if (Schema::hasTable('configs')) {
+		if (!Schema::hasColumn('photos', 'thumb2x')) {
+			if (Schema::hasTable('configs')) {
 
-			DB::table('configs')->insert([
-				[
-					'key'   => 'thumb_2x',
-					'value' => '1'
-				],
-				[
-					'key'   => 'small_2x',
-					'value' => '0'
-				],
-				[
-					'key'   => 'medium_2x',
-					'value' => '0'
-				],
-			]);
-		}
-		else {
-			echo "Table configs does not exists\n";
+				DB::table('configs')->insert([
+					[
+						'key'   => 'thumb_2x',
+						'value' => '1'
+					],
+					[
+						'key'   => 'small_2x',
+						'value' => '0'
+					],
+					[
+						'key'   => 'medium_2x',
+						'value' => '0'
+					],
+				]);
+			}
+			else {
+				echo "Table configs does not exists\n";
+			}
+
+			if (Schema::hasTable('photos')) {
+				Schema::table('photos', function (Blueprint $table) {
+					$table->renameColumn('medium', 'medium_old');
+					$table->renameColumn('small', 'small_old');
+				});
+
+				Schema::table('photos', function (Blueprint $table) {
+					$table->char('medium', 20)->default('');
+					$table->char('medium2x', 20)->default('');
+					$table->char('small', 20)->default('');
+					$table->char('small2x', 20)->default('');
+					$table->boolean('thumb2x')->default(true);
+				});
+			}
 		}
 
 		if (Schema::hasTable('photos')) {
-			Schema::table('photos', function (Blueprint $table) {
-				$table->renameColumn('medium', 'medium_old');
-				$table->renameColumn('small', 'small_old');
-			});
-
-			Schema::table('photos', function (Blueprint $table) {
-				$table->char('medium', 20)->default('');
-				$table->char('medium2x', 20)->default('');
-				$table->char('small', 20)->default('');
-				$table->char('small2x', 20)->default('');
-				$table->boolean('thumb2x')->default(true);
-			});
-
 			$photos = Photo::all();
 			foreach ($photos as $photo) {
 				$save = false;
@@ -73,14 +77,26 @@ class AddHidpi extends Migration
 
 				// Extract the sizes of medium and small
 				if ($photo->medium_old == '1') {
-					list($width, $height) = getimagesize(Config::get('defines.dirs.LYCHEE_UPLOADS_MEDIUM').$photo->url);
-					$photo->medium = $width.'x'.$height;
-					$save = true;
+					if (file_exists(Config::get('defines.dirs.LYCHEE_UPLOADS_MEDIUM').$photo->url)) {
+						list($width, $height) = getimagesize(Config::get('defines.dirs.LYCHEE_UPLOADS_MEDIUM').$photo->url);
+						$photo->medium = $width.'x'.$height;
+						$save = true;
+					}
+					else {
+						echo "Missing file ".Config::get('defines.dirs.LYCHEE_UPLOADS_MEDIUM').$photo->url."\n";
+						$this->failMessage();
+					}
 				}
 				if ($photo->small_old == '1') {
-					list($width, $height) = getimagesize(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$photo->url);
-					$photo->small = $width.'x'.$height;
-					$save = true;
+					if (file_exists(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$photo->url)) {
+						list($width, $height) = getimagesize(Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$photo->url);
+						$photo->small = $width.'x'.$height;
+						$save = true;
+					}
+					else {
+						echo "Missing file ".Config::get('defines.dirs.LYCHEE_UPLOADS_SMALL').$photo->url."\n";
+						$this->failMessage();
+					}
 				}
 
 				if ($save) {
@@ -95,6 +111,24 @@ class AddHidpi extends Migration
 		}
 		else {
 			echo "Table photos does not exist\n";
+		}
+	}
+
+
+
+	/**
+     * Provide diagnostics to the caller
+     *
+     * @return void
+     */
+	private function failMessage()
+	{
+		$ignoreFile = Config::get('defines.dirs.LYCHEE_UPLOADS').'/ignore-missing-files.txt';
+		if (!file_exists($ignoreFile)) {
+			echo "Please ensure that photos are moved to the new installation and run this command again!\n\n";
+			echo "To ignore, run this command again after creating a file at ".$ignoreFile."\n";
+			echo "You can then create intermediate sizes later using 'php artisan generate_thumbs'\n";
+			exit(1);
 		}
 	}
 


### PR DESCRIPTION
Fixes #144 

Makes the hidpi migration more robust and restartable.

Since I don't think we can pass any arguments to migrations, I opted for a slightly unsightly solution of asking user to create a file with a particular name (contents irrelevant) if they want to ignore the problem and continue without small/medium images. Let me know if this is OK.

I tested the ignoring and it works but is not perfect. The test for missing thumb@2x photos gets triggered so thumb2x gets set to 0 for each photo. And we don't currently have any way to reset it. Should we extend `php artisan generate_thumbs` to add support for square thumbs generation as well?