### PR TITLE
Don't fail if user.css is not writeable

### DIFF
--- a/app/Http/Controllers/DiagnosticsController.php
+++ b/app/Http/Controllers/DiagnosticsController.php
@@ -83,8 +83,8 @@ class DiagnosticsController extends Controller
 			$errors += ['Error: \'uploads/\' is missing or has insufficient read/write privileges'];
 		}
 		if (Helpers::hasPermissions(Config::get('defines.dirs.LYCHEE_DIST').'/user.css')===false) {
-			$errors .= ('Warning: \'dist/user.css\' does not exist or has insufficient read/write privileges.' . PHP_EOL);
-			if (Helpers::hasPermissions(Config::get('defines.dirs.LYCHEE_DIST'))===false)			$errors .= ('Warning: \'dist/\' has insufficient read/write privileges.' . PHP_EOL);
+			$errors += ['Warning: \'dist/user.css\' does not exist or has insufficient read/write privileges.'];
+			if (Helpers::hasPermissions(Config::get('defines.dirs.LYCHEE_DIST'))===false)			$errors += ['Warning: \'dist/\' has insufficient read/write privileges.'];
 		}
 
 		//        if (Helpers::hasPermissions(Config::get('defines.dirs.LYCHEE_DATA'))===false)           $errors += ['Error: \'data/\' is missing or has insufficient read/write privileges'];


### PR DESCRIPTION
Diagnostics fails with "Server error" if user.css does not have sufficient permissions. I just tweaked the code to match the lines above the failing lines and that seems to have fixed it.