### PR TITLE
Ensure correct padding of id on both ends

### DIFF
--- a/app/ModelFunctions/Helpers.php
+++ b/app/ModelFunctions/Helpers.php
@@ -13,13 +13,12 @@ class Helpers
 	{
 
 		// Generate id based on the current microtime
-		$id = str_replace(' ', '', microtime(true));
+		// Ensure 4 digits after the decimal point, 15 characters
+		// total (including the decimal point), 0-padded on the
+		// left if needed (shouldn't be needed unless we move back in
+		// time :-) )
+		$id = sprintf("%015.4f", microtime(true));
 		$id = str_replace('.', '', $id);
-
-		// Ensure that the id has a length of 14 chars
-		while (strlen($id) < 14) {
-			$id = '0'.$id;
-		}
 
 		// Return id as a string. Don't convert the id to an integer
 		// as 14 digits are too big for 32bit PHP versions.


### PR DESCRIPTION
Should fix #123.

I encountered the same problem as @SerenaButler but without migration from v3. Basically, if the fourth digit after the decimal point is `0` (one in ten chance, obviously), `id` ends up being a digit short so sorting by it is broken.

I replaced the custom code we had with a single call to good old C-style `sprintf()` which gets us pretty much everything we want here: guaranteed 4 decimal digits and 14 digits total, 0-padded on the left if need (which it never will be, unless we move back to 2001). All I kept was the code that removes the dot.