### PR TITLE
skip csrf verification if an api key is set and present

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -2,32 +2,50 @@
 
 namespace App\Http\Middleware;
 
+use App\Configs;
 use Closure;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
-use Illuminate\Http\Request;
-use App\Configs;
 
 class VerifyCsrfToken extends Middleware
 {
-    /**
-     * The URIs that should be excluded from CSRF verification.
-     *
-     * @var array
-     */
-    protected $except = [
-        // entry point...
-        '/php/index.php'
-    ];
+	/**
+	 * The URIs that should be excluded from CSRF verification.
+	 *
+	 * @var array
+	 */
+	protected $except = [
+		// entry point...
+		'/php/index.php'
+	];
 
-    public function handle(Request $request, Closure $next)
-    {
-        if ($request->is('api/*')) {
-            $apiKey = Configs::get_value('api_key');
-            if ($apiKey && $request->header('Authorization') === $apiKey) {
-                return $next($request);
-            }
-        }
 
-        return parent::handle($request, $next);
-    }
+
+	public function handle($request, Closure $next)
+	{
+		if ($request->is('/api/*')) {
+
+			/**
+			 * default value is ''
+			 * we force it in case of the migration has not been done.
+			 */
+			$apiKey = Configs::get_value('api_key', '');
+
+			/**
+			 * if apiKey is the empty string we directly return the parent handle.
+			 */
+			if ($apiKey && $apiKey == '') {
+				return parent::handle($request, $next);
+			}
+
+			/**
+			 * We are currently checking for Authorization.
+			 * Do we also want to check if there is a POST value with the apiKey ?
+			 */
+			if ($apiKey && $request->header('Authorization') === $apiKey) {
+				return $next($request);
+			}
+		}
+
+		return parent::handle($request, $next);
+	}
 }

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -2,7 +2,10 @@
 
 namespace App\Http\Middleware;
 
+use Closure;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+use Illuminate\Http\Request;
+use App\Configs;
 
 class VerifyCsrfToken extends Middleware
 {
@@ -15,4 +18,16 @@ class VerifyCsrfToken extends Middleware
         // entry point...
         '/php/index.php'
     ];
+
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->is('api/*')) {
+            $apiKey = Configs::get_value('api_key');
+            if ($apiKey && $request->header('Authorization') === $apiKey) {
+                return $next($request);
+            }
+        }
+
+        return parent::handle($request, $next);
+    }
 }

--- a/database/migrations/2019_03_29_185414_add_api_key.php
+++ b/database/migrations/2019_03_29_185414_add_api_key.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddApiKey extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+	    if (Schema::hasTable('configs')) {
+
+		    DB::table('configs')->insert([
+			    ['key' => 'api_key', 'value' => ''],
+		    ]);
+	    }
+	    else {
+		    echo "Table configs does not exists\n";
+	    }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+	    if (env('DB_DROP_CLEAR_TABLES_ON_ROLLBACK', false)) {
+		    Configs::where('key', '=', 'api_key')->delete();
+	    }
+    }
+}


### PR DESCRIPTION
Check the `Authorization` header to make sure an API key is present and matches what is in the config table (assuming what is a valid string)