### PR TITLE
Add support for short ids on 32-bit systems

### DIFF
--- a/app/Http/Controllers/DiagnosticsController.php
+++ b/app/Http/Controllers/DiagnosticsController.php
@@ -39,6 +39,10 @@ class DiagnosticsController extends Controller
 		if (floatval(phpversion()) < 7) {
 			$errors += ['Error: Upgrade to PHP 7 or higher'];
 		}
+		// 32 or 64 bits ?
+		if (PHP_INT_MAX == 2147483647) {
+			$errors += ['Warning: Using 32 bit Php, recommended upgrade to 64 bit'];
+		}
 
 		// Extensions
 		if (!extension_loaded('session')) {

--- a/app/Http/Controllers/DiagnosticsController.php
+++ b/app/Http/Controllers/DiagnosticsController.php
@@ -39,10 +39,6 @@ class DiagnosticsController extends Controller
 		if (floatval(phpversion()) < 7) {
 			$errors += ['Error: Upgrade to PHP 7 or higher'];
 		}
-		// 32 or 64 bits ?
-		if (PHP_INT_MAX == 2147483647) {
-			$errors += ['Error: Using 32 bit Php, currently unsupported (maybe in the future)'];
-		}
 
 		// Extensions
 		if (!extension_loaded('session')) {

--- a/app/ModelFunctions/Helpers.php
+++ b/app/ModelFunctions/Helpers.php
@@ -13,15 +13,23 @@ class Helpers
 	{
 
 		// Generate id based on the current microtime
-		// Ensure 4 digits after the decimal point, 15 characters
-		// total (including the decimal point), 0-padded on the
-		// left if needed (shouldn't be needed unless we move back in
-		// time :-) )
-		$id = sprintf("%015.4f", microtime(true));
-		$id = str_replace('.', '', $id);
 
-		// Return id as a string. Don't convert the id to an integer
-		// as 14 digits are too big for 32bit PHP versions.
+		if (PHP_INT_MAX == 2147483647) {
+			// For 32-bit installations, we can only afford to store the
+			// full seconds in id.  The calling code needs to be able to
+			// handle duplicate ids.  Note that this also exposes us to
+			// the year 2038 problem.
+			$id = sprintf("%010d", microtime(true));
+		}
+		else {
+			// Ensure 4 digits after the decimal point, 15 characters
+			// total (including the decimal point), 0-padded on the
+			// left if needed (shouldn't be needed unless we move back in
+			// time :-) )
+			$id = sprintf("%015.4f", microtime(true));
+			$id = str_replace('.', '', $id);
+		}
+
 		return $id;
 
 	}

--- a/database/migrations/2019_04_07_193345_fix_32bit.php
+++ b/database/migrations/2019_04_07_193345_fix_32bit.php
@@ -1,0 +1,93 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class Fix32Bit extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		if (PHP_INT_MAX > 2147483647) {
+			return;
+		}
+
+		// We need to chop off four least significant digits from the ids to
+		// make them fit within a 32-bit integer.
+
+		Schema::disableForeignKeyConstraints();
+
+		// Start with the ids of 'albums' sincne they also affect the
+		// album_ids in 'photos'.
+		$albums = DB::table('albums')->get();
+		$prevShortId = 0;
+		foreach ($albums as $album) {
+			// Chop off the last four digits.
+			$shortId = intval(substr($album->id, 0, -4));
+			if ($shortId <= $prevShortId) {
+				$shortId = $prevShortId + 1;
+			}
+			DB::table('albums')->where('id', '=', $album->id)->update([
+				'id' => $shortId
+			]);
+			DB::table('photos')->where('album_id', '=', $album->id)->update([
+				'album_id' => $shortId
+			]);
+			$prevShortId = $shortId;
+		}
+
+		$photos = DB::table('photos')->get();
+		$prevShortId = 0;
+		foreach ($photos as $photo) {
+			// Chop off the last four digits.
+			$shortId = intval(substr($photo->id, 0, -4));
+			if ($shortId <= $prevShortId) {
+				$shortId = $prevShortId + 1;
+			}
+			DB::table('photos')->where('id', '=', $photo->id)->update([
+				'id' => $shortId
+			]);
+			$prevShortId = $shortId;
+		}
+
+		Schema::enableForeignKeyConstraints();
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		if (PHP_INT_MAX > 2147483647) {
+			return;
+		}
+
+		Schema::disableForeignKeyConstraints();
+
+		// The chopped off digits are lost but we can always add some zeros.
+
+		$albums = DB::table('albums')->get();
+		foreach ($albums as $album) {
+			DB::table('albums')->where('id', '=', $album->id)->update([
+				'id' => $album->id.'0000'
+			]);
+		}
+
+		$photos = DB::table('photos')->get();
+		foreach ($photos as $photo) {
+			DB::table('photos')->where('id', '=', $photo->id)->update([
+				'id' => $photo->id.'0000',
+				'album_id' => $photo->album_id.'0000'
+			]);
+		}
+
+		Schema::enableForeignKeyConstraints();
+	}
+}


### PR DESCRIPTION
Fixes #163

This is a first attempt at support for PHP installations with 32-bit integers. This should address #163.

Not having a 32-bit system around, I wasn't able to test it properly, but hopefully others will be able to confirm if it works.

I didn't add database migration yet so don't try it when migrating an existing v3 installation. For now, it's for fresh v4 installations only. @ildyria can you help with the migration? I'm guessing we need a way to convert those big integers to strings outside of PHP, so that we can then chop the last 4 digits off and store the remaining 32-bit int. Only how to do this? Databases are not my forte.. Also, I'm assuming that we can keep the "big" column types even on 32-bit systems, so long as we ensure that any data we put in is 32-bit?

Here's an overview of the code changes:

`Helpers::generateID()` is modified to return full seconds on 32-bit systems.

`PhotoFunctions::save()` is hardened to correctly deal with duplicate ids, which are much more likely given the full-second resolution on 32-bit systems. I removed the initial `while` loop which wasn't necessary, was inherently race'y, and was filling the logs with tons of messages. I replaced recursion with a loop since the recursion could be arbitrarily deep and I wasn't sure how gracefully PHP could handle that. `errorCode` was being extracted from a wrong field so test for `1062` would never trigger. Finally, I added a random sub-1s `usleep()` to eliminate busy-looping if duplicate id is detected.

For the sake of completeness, I duplicated that code in `AlbumFunctions::create()`. It's far less likely to ever trigger, given that albums are created one at a time, but better to be thorough, I think.