### PR TITLE
monkey patch:  fixup app/Configs 'Creating default object from empty value' error

### DIFF
--- a/app/Configs.php
+++ b/app/Configs.php
@@ -100,6 +100,10 @@ class Configs extends Model
 	{
 
 		$config = Configs::where('key', '=', $key)->first();
+		//first() may return null, fixup 'Creating default object from empty value' error
+		if ($config == null) {
+			return true;
+		}
 		$config->value = $value;
 		if (!$config->save()) {
 			Logs::error(__METHOD__, __LINE__, $config->getErrors());

--- a/app/Configs.php
+++ b/app/Configs.php
@@ -102,6 +102,7 @@ class Configs extends Model
 		$config = Configs::where('key', '=', $key)->first();
 		//first() may return null, fixup 'Creating default object from empty value' error
 		if ($config == null) {
+			Logs::warning(__FUNCTION__,__LINE__, 'key '.$key.' not found!');
 			return true;
 		}
 		$config->value = $value;


### PR DESCRIPTION
Fixes #164

```
Request URL: http://127.0.0.1:90/api/Settings::saveAll
Request Method: POST

Status Code: 500 Internal Server Error
message: "Server Error"
```

```php
{
    "message": "Creating default object from empty value",
    "exception": "ErrorException",
    "file": "/app/Lychee-Laravel/app/Configs.php",
    "line": 103,
    "trace": [
        {
            "file": "/app/Lychee-Laravel/app/Configs.php",
            "line": 103,
            "function": "handleError",
            "class": "Illuminate\\Foundation\\Bootstrap\\HandleExceptions",
            "type": "->"
        },
    ]
}
```

then I found the reason:
```
$config = Configs::where('key', '=', $key)->first();
//without Check $config is null or not
$config->value = $value;
```
but, this is not the root cause.

the reason is that the method get a `key` param with an invalid value `Settings::saveAll`
of course this does not exists.

so I think this is just a work ground. a monkey patch