### PR TITLE
Improve update check, and add it to diagnostics

### DIFF
--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -6,6 +6,7 @@ use App\Album;
 use App\Configs;
 use App\Locale\Lang;
 use App\Logs;
+use App\Metadata\GitHubFunctions;
 use App\ModelFunctions\ConfigFunctions;
 use App\ModelFunctions\SessionFunctions;
 use App\User;
@@ -26,6 +27,10 @@ class SessionController extends Controller
 	 * @var SessionFunctions
 	 */
 	private $sessionFunctions;
+	/**
+	 * @var GitHubFunctions
+	 */
+	private $gitHubFunctions;
 
 
 
@@ -33,10 +38,11 @@ class SessionController extends Controller
 	 * @param ConfigFunctions $configFunctions
 	 * @param SessionFunctions $sessionFunctions
 	 */
-	public function __construct(ConfigFunctions $configFunctions, SessionFunctions $sessionFunctions)
+	public function __construct(ConfigFunctions $configFunctions, SessionFunctions $sessionFunctions, GitHubFunctions $gitHubFunctions)
 	{
 		$this->configFunctions = $configFunctions;
 		$this->sessionFunctions = $sessionFunctions;
+		$this->gitHubFunctions = $gitHubFunctions;
 	}
 
 
@@ -109,7 +115,7 @@ class SessionController extends Controller
 		$return['update_json'] = 0;
 		$return['update_available'] = false;
 
-		$this->sessionFunctions->checkUpdates($return);
+		$this->gitHubFunctions->checkUpdates($return);
 
 		return $return;
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -243,13 +243,9 @@ class SettingsController extends Controller
 	{
 
 		$no_error = true;
-		foreach ($request->except('_token') as $key => $value) {
-			if ($key != 'function') {
-				// just because we do not want null values
+		foreach ($request->except(['_token','function']) as $key => $value) {
 				$value = ($value == null) ? '' : $value;
-
 				$no_error &= Configs::set($key, $value);
-			}
 		}
 		return $no_error ? 'true' : 'false';
 	}

--- a/app/Metadata/GitHubFunctions.php
+++ b/app/Metadata/GitHubFunctions.php
@@ -1,0 +1,208 @@
+<?php
+
+
+namespace App\Metadata;
+
+
+use App\Configs;
+use App\Logs;
+
+class GitHubFunctions
+{
+
+	private $commits = false;
+	private $head = false;
+	private $branch = false;
+
+
+
+	private function trim($commit_id)
+	{
+		return trim(substr($commit_id, 0, 7));
+	}
+
+
+
+	/**
+	 * Fetch an url with 1sec timout.
+	 * @param $url
+	 * @return bool|mixed
+	 */
+	private function get_json($url)
+	{
+		$opts = [
+			'http' => [
+				'method'  => 'GET',
+				'timeout' => 1,
+				'header'  => [
+					'User-Agent: PHP'
+				]
+			]
+		];
+		$context = stream_context_create($opts);
+
+		$json = @file_get_contents($url, false, $context);
+		if ($json != false) {
+			return json_decode($json);
+		}
+		Logs::notice(__FUNCTION__, __LINE__, "Could not access: ".$url);
+		return false;
+	}
+
+
+
+	/**
+	 * look at .git/HEAD and return the current branch
+	 * @return false|string
+	 */
+	public function get_current_branch()
+	{
+		if ($this->branch == false) {
+			$this->branch = @file_get_contents('../.git/HEAD');
+			if ($this->branch != false) {
+				$this->branch = explode("/", $this->branch, 3)[2]; //separate out by the "/" in the string
+			}
+			$this->branch = $this->trim($this->branch);
+		}
+		return $this->branch;
+	}
+
+
+
+	/**
+	 * Return the current commit id (7 hex digits)
+	 * @return false|string
+	 */
+	public function get_current_commit()
+	{
+		if ($this->head == false && $this->get_current_branch() != false) {
+			$this->head = @file_get_contents(sprintf('../.git/refs/heads/%s', $this->branch));
+			if ($this->head != false) {
+				$this->head = $this->trim($this->head);
+			}
+		}
+		return $this->head;
+	}
+
+
+
+	/**
+	 * @return bool
+	 */
+	public function get_commits()
+	{
+		if (!$this->commits) {
+			$branch = $this->get_current_branch();
+			if ($branch != 'master') {
+				return false;
+			}
+
+			$head = $this->get_current_commit();
+			if ($head == false) {
+				return false;
+			}
+
+			// get 30 last commits.
+			$this->commits = $this->get_json('http://api.github.com/repos/LycheeOrg/Lychee-Laravel/commits');
+		}
+		return $this->commits;
+	}
+
+
+
+	/**
+	 * Return a string like 'commit number (branch)' or 'no git data found'
+	 * @return string
+	 */
+	public function get_info()
+	{
+		$branch = $this->get_current_branch();
+		$head = $this->get_current_commit();
+		if ($head == false || $branch == false) {
+			return 'No git data found. Probably installed from release.';
+		}
+		return sprintf('%s (%s)', $head, $branch).$this->get_behind_text();
+	}
+
+
+
+	/**
+	 * Counter number of commits between current version and master/HEAD
+	 * @return bool|int
+	 */
+	public function count_behind()
+	{
+		$head = $this->get_current_commit();
+
+		/** @var bool|array $commits */
+		$commits = $this->get_commits();
+		if ($commits == false) {
+			return false;
+		}
+
+		$i = 0;
+		while ($i < count($commits)) {
+			if ($this->trim($commits[$i]->sha) == $head) {
+				break;
+			}
+			$i++;
+		}
+
+		return ($i == count($commits)) ? false : $i;
+	}
+
+
+
+	/**
+	 * @return string
+	 */
+	public function get_github_head()
+	{
+		$commits = $this->get_commits();
+		return ($commits != false) ? ' ('.$this->trim($commits[0]).')' : '';
+	}
+
+
+
+	/**
+	 * Check if current version is
+	 * @return string
+	 */
+	public function get_behind_text()
+	{
+		$branch = $this->get_current_branch();
+		if ($branch != 'master') {
+			return ' - Branch is not master, cannot compare.';
+		}
+
+		if ($this->get_commits() == false) {
+			return ' - Check for update failed.';
+		}
+
+		$count = $this->count_behind();
+		if ($count != false) {
+			return ' - '.$count.' commits behind master'.$this->get_github_head();
+		}
+
+		return ' - Probably more than 30 commits behind master';
+	}
+
+
+
+	/**
+	 * Check for updates
+	 *
+	 * @param $return
+	 */
+	public function checkUpdates(&$return)
+	{
+		// add a setting to do this check only once per day ?
+		if (Configs::get_value('checkForUpdates', '0') == '1') {
+			$json = $this->get_json('https://lycheeorg.github.io/update.json');
+			if ($json != false) {
+				$return['update_json'] = $json->lychee->version;
+				$return['update_available'] = ((intval(Configs::get_value('version', '40000'))) < $return['update_json']);
+			}
+		}
+	}
+}

--- a/app/ModelFunctions/Helpers.php
+++ b/app/ModelFunctions/Helpers.php
@@ -2,6 +2,8 @@
 
 namespace App\ModelFunctions;
 
+use App\Logs;
+
 class Helpers
 {
 	/**

--- a/app/ModelFunctions/SessionFunctions.php
+++ b/app/ModelFunctions/SessionFunctions.php
@@ -48,28 +48,4 @@ class SessionFunctions
 
 		return false;
 	}
-
-
-
-	/**
-	 * Check for updates
-	 *
-	 * @param $return
-	 */
-	public function checkUpdates(&$return)
-	{
-		$configs = Configs::get();
-
-		if ($configs['checkForUpdates'] == '1') {
-			try {
-				$json = file_get_contents('https://lycheeorg.github.io/update.json');
-				$obj = json_decode($json);
-				$return['update_json'] = $obj->lychee->version;
-				$return['update_available'] = ((intval($configs['version'])) < $return['update_json']);
-			}
-			catch (\Exception $e) {
-				Logs::notice(__METHOD__, __LINE__, 'Could not access: https://lycheeorg.github.io/update.json');
-			}
-		}
-	}
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,9 +4,10 @@ namespace App\Providers;
 
 use App\Configs;
 use App\Image;
+use App\Metadata\GitHubFunctions;
 use App\ModelFunctions\AlbumFunctions;
-use App\ModelFunctions\PhotoFunctions;
 use App\ModelFunctions\ConfigFunctions;
+use App\ModelFunctions\PhotoFunctions;
 use App\ModelFunctions\SessionFunctions;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -14,45 +15,49 @@ use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
-    public $singletons = [
-        AlbumFunctions::class => AlbumFunctions::class,
-        PhotoFunctions::class => PhotoFunctions::class,
-        ConfigFunctions::class => ConfigFunctions::class,
-        SessionFunctions::class => SessionFunctions::class,
-    ];
+	public $singletons = [
+		AlbumFunctions::class   => AlbumFunctions::class,
+		PhotoFunctions::class   => PhotoFunctions::class,
+		ConfigFunctions::class  => ConfigFunctions::class,
+		SessionFunctions::class => SessionFunctions::class,
+		GitHubFunctions::class  => GitHubFunctions::class
+	];
 
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-    	if(config('app.debug', false))
-	    {
-		    DB::listen(function($query) {
-			    Log::info(
-				    $query->sql,
-				    $query->bindings,
-				    $query->time
-			    );
-		    });
-	    }
-    }
 
-    /**
-     * Register any application services.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        $this->app->singleton(Image\ImageHandlerInterface::class, function ($app) {
-            $compressionQuality = Configs::get_value('compression_quality', 90);
-            if (Configs::hasImagick()) {
-                return new Image\ImagickHandler($compressionQuality);
-            }
-            return new Image\GdHandler($compressionQuality);
-        });
-    }
+
+	/**
+	 * Bootstrap any application services.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		if (config('app.debug', false)) {
+			DB::listen(function ($query) {
+				Log::info(
+					$query->sql,
+					$query->bindings,
+					$query->time
+				);
+			});
+		}
+	}
+
+
+
+	/**
+	 * Register any application services.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+		$this->app->singleton(Image\ImageHandlerInterface::class, function ($app) {
+			$compressionQuality = Configs::get_value('compression_quality', 90);
+			if (Configs::hasImagick()) {
+				return new Image\ImagickHandler($compressionQuality);
+			}
+			return new Image\GdHandler($compressionQuality);
+		});
+	}
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,8 +89,8 @@ Route::post('/api/User::Create',                'UserController@create')->middle
 Route::post('/api/Logs',                        'LogController@display')->middleware('admin');
 Route::post('/api/Logs::clearNoise',            'LogController@clearNoise')->middleware('admin');
 Route::get('/api/Logs::clear',                  'LogController@clear')->middleware('admin');
-Route::post('/api/Diagnostics',                 'DiagnosticsController@show')->middleware('admin');
-Route::get('/api/Diagnostics',                  'DiagnosticsController@show')->middleware('admin');
+Route::post('/api/Diagnostics',                 'DiagnosticsController@show');
+Route::get('/Diagnostics',                      'DiagnosticsController@show');
 
 // unused
 Route::post('/api/Logs::clear',                 'LogController@clear')->middleware('admin');


### PR DESCRIPTION
This PR centralize GitHub interactions (check for updates, check the current version of the installation) and improve the Diagnostics to inform the user whether it's installation is up to date or not.

It also set a timeout to the check for updates to 1 second instead of 1 minute as previously defined in php.ini.

