### PR TITLE
Support the Rename All functionality

### DIFF
--- a/app/Http/Controllers/AlbumController.php
+++ b/app/Http/Controllers/AlbumController.php
@@ -176,7 +176,7 @@ class AlbumController extends Controller
 	function setTitle(Request $request)
 	{
 		$request->validate([
-			'albumIDs' => 'integer|required',
+			'albumIDs' => 'string|required',
 			'title'    => 'string|required|max:100'
 		]);
 


### PR DESCRIPTION
The "Rename All" functionality in the front end does not work with Lychee-Laravel because of an input validation issue. This one-liner fixes it.