### PR TITLE
Check LensType as a fallback for lens

### DIFF
--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -189,6 +189,9 @@ class Extractor
 			if ($metadata['lens'] == '' && !empty($exif['UndefinedTag:0xA434'])) {
 				$metadata['lens'] = trim($exif['UndefinedTag:0xA434']);
 			}
+			if ($metadata['lens'] == '' && !empty($exif['LensType'])) {
+				$metadata['lens'] = trim($exif['LensType']);
+			}
 
 			// Deal with GPS coordinates
 			if (!empty($exif['GPSLatitude']) && !empty($exif['GPSLatitudeRef'])) {


### PR DESCRIPTION
One of my cameras (Panasonic GM1) does not store lens info in `LensInfo`, but in `LensType` instead. So add `LensType` as a fallback if the other two fields we already consult yield nothing.