### PR TITLE
Use portable detection of duplicate keys

### DIFF
--- a/app/ModelFunctions/AlbumFunctions.php
+++ b/app/ModelFunctions/AlbumFunctions.php
@@ -44,7 +44,7 @@ class AlbumFunctions
 			}
 			catch (QueryException $e) {
 				$errorCode = $e->getCode();
-				if ($errorCode == 1062) {
+				if ($errorCode == 23000 || $errorCode == 23505) {
 					// Duplicate entry
 					do {
 						usleep(rand(0, 1000000));

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -464,7 +464,7 @@ class PhotoFunctions
 			}
 			catch (QueryException $e) {
 				$errorCode = $e->getCode();
-				if ($errorCode == 1062) {
+				if ($errorCode == 23000 || $errorCode == 23505) {
 					// houston, we have a duplicate entry problem
 					do {
 						// Our ids are based on current system time, so


### PR DESCRIPTION
This will hopefully be a more portable way of detecting duplicate ids. `23505` is for PgSql, `23000` should be good for the rest.