### PR TITLE
Extractor::extract() fixup invalid metadata,

### DIFF
--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -205,6 +205,13 @@ class Extractor
 			}
 		}
 
+		//validate the data
+		foreach($metadata as $k => $v) {
+			//reset field value to empty string if the data is binary (invalid UTF-8 chars)
+			if (!mb_check_encoding($v)) {
+				$metadata[$k] = '';
+			}
+		}
 		return $metadata;
 	}
 


### PR DESCRIPTION
fixup invalid metadata,  which cause Laravel throw 'Malformed UTF-8 characters, possibly incorrectly encoded' error
and related album (include this jpg photo) is unable to open it.