### PR TITLE
Check parent_id when creating albums

### DIFF
--- a/app/Http/Middleware/UploadCheck.php
+++ b/app/Http/Middleware/UploadCheck.php
@@ -67,7 +67,7 @@ class UploadCheck
     public function album_check(Request $request, int $id)
     {
         if ($request->has('albumID') || $request->has('parent_id')) {
-            $albumID = $request[$request->has('albumID') ? 'albumID' : 'parent_id'];
+            $albumID = $request->has('albumID') ? $request['albumID'] : $request['parent_id'];
             if ($albumID == 'f' || $albumID == 's' || $albumID == 'r' || $albumID == 0)
                 return true;
 

--- a/app/Http/Middleware/UploadCheck.php
+++ b/app/Http/Middleware/UploadCheck.php
@@ -66,8 +66,8 @@ class UploadCheck
      */
     public function album_check(Request $request, int $id)
     {
-        if ($request->has('albumID')) {
-            $albumID = $request['albumID'];
+        if ($request->has('albumID') || $request->has('parent_id')) {
+            $albumID = $request[$request->has('albumID') ? 'albumID' : 'parent_id'];
             if ($albumID == 'f' || $albumID == 's' || $albumID == 'r' || $albumID == 0)
                 return true;
 


### PR DESCRIPTION
When checking upload permissions, check parent_id used with Album::add requests.