### PR TITLE
Don't set file timestamp if takestamp is null

### DIFF
--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -316,7 +316,7 @@ class PhotoFunctions
 			}
 
 			// Set original date
-			if ($info['takestamp'] !== '' && $info['takestamp'] !== 0) {
+			if ($info['takestamp'] !== '' && $info['takestamp'] !== 0 && $info['takestamp'] !== null) {
 				@touch($path, strtotime($info['takestamp']));
 			}
 


### PR DESCRIPTION
If an imported photo has no EXIF, `$info['takestamp']` is actually `null`.

I'm not sure if the existing two conditions will ever trigger but since they shouldn't hurt I just added one more...