### PR TITLE
Access correct id in OwnedBy

### DIFF
--- a/app/Photo.php
+++ b/app/Photo.php
@@ -528,7 +528,7 @@ class Photo extends Model
 	 */
 	public function scopeOwnedBy(Builder $query, $id)
 	{
-		return $id == 0 ? $query : $query->where('id', '=', $id);
+		return $id == 0 ? $query : $query->where('owner_id', '=', $id);
 	}
 
 }


### PR DESCRIPTION
Smart albums are always empty for non-admin users because `Photo::OwnedBy` checks `id` rather than `owner_id`.