### PR TITLE
Ensure that ownership follows parent album

### DIFF
--- a/app/Http/Controllers/AlbumController.php
+++ b/app/Http/Controllers/AlbumController.php
@@ -392,11 +392,10 @@ class AlbumController extends Controller
 		$no_error = true;
 		foreach ($photos as $photo) {
 			$photo->album_id = $albumID;
-			if ($this->sessionFunctions->is_admin()) {
-				// Admin can merge albums between users.  Make sure that the
-				// ownership changes in the process.
-				$photo->owner_id = $album->owner_id;
-			}
+
+			// just to be sure to handle ownership changes in the process.
+			$photo->owner_id = $album->owner_id;
+
 			$no_error &= $photo->save();
 		}
 

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -1,5 +1,6 @@
 <?php
 /** @noinspection PhpComposerExtensionStubsInspection */
+
 /** @noinspection PhpUndefinedClassInspection */
 
 namespace App\Http\Controllers;
@@ -12,6 +13,7 @@ use App\ModelFunctions\PhotoFunctions;
 use App\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Session;
 use ImagickException;
 
 class ImportController extends Controller
@@ -218,7 +220,7 @@ class ImportController extends Controller
 					// Album creation
 
 					// Folder
-					$album = $this->albumFunctions->create(basename($file), $albumID);
+					$album = $this->albumFunctions->create(basename($file), $albumID, Session::get('UserID'));
 					// this actually should not fail.
 					if ($album === false) {
 						$error = true;

--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -283,7 +283,7 @@ class PhotoController extends Controller
 		$albumID = $request['albumID'];
 
 		$album = null;
-		if (Session::get('UserID') === 0 && $albumID !== '0') {
+		if ($this->sessionFunctions->is_admin() && $albumID !== '0') {
 			// Admin can move photos between users.  Make sure that the
 			// ownership changes in the process.
 			$album = Album::find($albumID);

--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -283,9 +283,8 @@ class PhotoController extends Controller
 		$albumID = $request['albumID'];
 
 		$album = null;
-		if ($this->sessionFunctions->is_admin() && $albumID !== '0') {
-			// Admin can move photos between users.  Make sure that the
-			// ownership changes in the process.
+		if ($albumID !== '0') {
+			// just to be sure to handle ownership changes in the process.
 			$album = Album::find($albumID);
 			if ($album === null) {
 				Logs::error(__METHOD__, __LINE__, 'Could not find specified album');

--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -282,9 +282,23 @@ class PhotoController extends Controller
 
 		$albumID = $request['albumID'];
 
+		$album = null;
+		if (Session::get('UserID') === 0 && $albumID !== '0') {
+			// Admin can move photos between users.  Make sure that the
+			// ownership changes in the process.
+			$album = Album::find($albumID);
+			if ($album === null) {
+				Logs::error(__METHOD__, __LINE__, 'Could not find specified album');
+				return false;
+			}
+		}
+
 		$no_error = true;
 		foreach ($photos as $photo) {
 			$photo->album_id = ($albumID == '0') ? null : $albumID;
+			if ($album !== null) {
+				$photo->owner_id = $album->owner_id;
+			}
 			$no_error &= $photo->save();
 		}
 		Album::reset_takestamp();

--- a/app/ModelFunctions/AlbumFunctions.php
+++ b/app/ModelFunctions/AlbumFunctions.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Session;
 class AlbumFunctions
 {
 
+
 	/**
 	 * given an albumID return if the said album is "smart"
 	 *
@@ -37,29 +38,29 @@ class AlbumFunctions
 	 *
 	 * @param string $title
 	 * @param int $parent_id
+	 * @param int $user_id
 	 * @return Album|string
 	 */
-	public function create(string $title, int $parent_id): Album
+	public function create(string $title, int $parent_id, int $user_id): Album
 	{
+		$parent = Album::find($parent_id);
+		// we get the parent if it exists.
+
 		$album = new Album();
 		$album->id = Helpers::generateID();
 		$album->title = $title;
 		$album->description = '';
-		$album->parent_id = ($parent_id === 0 ? null : $parent_id);
 
-		if (Session::get('login') && Session::get('UserID') === 0 && $parent_id !== 0) {
+		if ($parent !== null) {
+			$album->parent_id = $album->id;
+
 			// Admin can add subalbums to other users' albums.  Make sure that
 			// the ownership stays with that user.
-			$parentAlb = Album::find($parent_id);
-			if ($parentAlb === null) {
-				Logs::error(__METHOD__, __LINE__, 'Could not find specified album');
-				return Response::error('Could not find specified album');
-			}
-
-			$album->owner_id = $parentAlb->owner_id;
+			$album->owner_id = $parent->owner_id;
 		}
 		else {
-			$album->owner_id = Session::get('UserID');
+			$album->parent_id = null;
+			$album->owner_id = $user_id;
 		}
 
 		do {

--- a/app/ModelFunctions/AlbumFunctions.php
+++ b/app/ModelFunctions/AlbumFunctions.php
@@ -52,7 +52,7 @@ class AlbumFunctions
 		$album->description = '';
 
 		if ($parent !== null) {
-			$album->parent_id = $album->id;
+			$album->parent_id = $parent->id;
 
 			// Admin can add subalbums to other users' albums.  Make sure that
 			// the ownership stays with that user.

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -301,10 +301,24 @@ class PhotoFunctions
 		$photo->longitude = $info['longitude'];
 		$photo->altitude = $info['altitude'];
 		$photo->public = $public;
-		$photo->owner_id = Session::get('UserID');
 		$photo->star = $star;
 		$photo->checksum = $checksum;
 		$photo->album_id = $albumID;
+
+		if (Session::get('login') && Session::get('UserID') === 0 && $albumID !== null) {
+			// Admin can add photos to other users' albums.  Make sure that
+			// the ownership stays with that user.
+			$album = Album::find($albumID);
+			if ($album === null) {
+				Logs::error(__METHOD__, __LINE__, 'Could not find specified album');
+				return Response::error('Could not find specified album');
+			}
+
+			$photo->owner_id = $album->owner_id;
+		}
+		else {
+			$photo->owner_id = Session::get('UserID');
+		}
 
 		if ($exists === false) {
 

--- a/app/ModelFunctions/SessionFunctions.php
+++ b/app/ModelFunctions/SessionFunctions.php
@@ -124,7 +124,8 @@ class SessionFunctions
 	 * @param $albumID
 	 * @return bool
 	 */
-	public function has_visible_album($albumID){
+	public function has_visible_album($albumID)
+	{
 		if (!Session::has('visible_albums')) {
 			return false;
 		}


### PR DESCRIPTION
This is a first attempt to fix an issue where admin could create/move photos and albums around resulting in mixed-ownership album content, etc.

This patch ensure that all add, move, and merge operations performed by admin change the ownership of moved objects to that of the destination album, if any.

I tried to take advantage of the new session infrastructure but I wasn't always successful, e.g., in AlbumFunctions (is it possible to invoke SessionFunction from them?).