### PR TITLE
Revert an erroneous change from #236

### DIFF
--- a/app/Http/Controllers/PhotoController.php
+++ b/app/Http/Controllers/PhotoController.php
@@ -75,7 +75,9 @@ class PhotoController extends Controller
 
 			$return = $photo->prepareData();
 			$return['original_album'] = $return['album'];
-			$return['album'] = $photo->album_id;
+			// This way preserves the back button functionality for photos
+			// in smart albums.
+			$return['album'] = $request['albumID'];
 			return $return;
 		}
 


### PR DESCRIPTION
@ildyria, turns out that one of your changes in #236 broke the back button functionality for photos in smart albums.

This commit reverts the change and adds a comment so that we don't break it again :smiley:.