### PR TITLE
Remove a spurious divider

### DIFF
--- a/resources/views/gallery.blade.php
+++ b/resources/views/gallery.blade.php
@@ -98,7 +98,6 @@
         <a class="button button--eye" id="button_share" title="{{ $locale['SHARE_PHOTO'] }}">
             <svg class="iconic"><use xlink:href="#eye"></use></svg>
         </a>
-        <a class="header__divider"></a>
         <a class="button button--info" id="button_info" title="{{ $locale['ABOUT_PHOTO'] }}">
             <svg class="iconic"><use xlink:href="#info"></use></svg>
         </a>


### PR DESCRIPTION
I somehow missed this file from my user access fixes PR.

Basically, it removes the divider in the photo view between share and info buttons. In my view, that divider is unnecessary and it's unclear why it should be there (it doesn't group obviously similar operations). It is also inconsistent as there is no such divider in the album view.