### PR TITLE
fixup invalid shutter data "0/0 s" caused Modulo by zero exception

### DIFF
--- a/app/ModelFunctions/Helpers.php
+++ b/app/ModelFunctions/Helpers.php
@@ -2,6 +2,8 @@
 
 namespace App\ModelFunctions;
 
+use Exception;
+
 class Helpers
 {
 	/**
@@ -84,10 +86,16 @@ class Helpers
 	 * @param $a
 	 * @param $b
 	 *
+	 * @throws Exception
+	 *
 	 * @return mixed
 	 */
 	public static function gcd($a, $b)
 	{
+		if ($b == 0) {
+			throw new Exception('gcd: Modulo by zero error.');
+		}
+
 		return ($a % $b) ? Helpers::gcd($b, $a % $b) : $b;
 	}
 }

--- a/app/Photo.php
+++ b/app/Photo.php
@@ -192,7 +192,7 @@ class Photo extends Model
 		$photo['license'] = Configs::get_value('default_license'); // default
 
 		// shutter speed needs to be processed. It is stored as a string `a/b s`
-		if ($photo['shutter'] != '' && substr($photo['shutter'], 0, 2) != '1/') {
+		if ($photo['shutter'] != '' && substr($photo['shutter'], 0, 2) != '1/' && substr($photo['shutter'], 1, 2) != '/0') {
 			preg_match('/(\d+)\/(\d+) s/', $photo['shutter'], $matches);
 			if ($matches) {
 				$a = intval($matches[1]);

--- a/app/Photo.php
+++ b/app/Photo.php
@@ -6,6 +6,7 @@ namespace App;
 
 use App\ModelFunctions\Helpers;
 use Eloquent;
+use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -160,6 +161,8 @@ class Photo extends Model
 	 * Returns photo-attributes into a front-end friendly format. Note that some attributes remain unchanged.
 	 *
 	 * @return array returns photo-attributes in a normalized structure
+	 *
+	 * @throws Exception
 	 */
 	public function prepareData()
 	{
@@ -192,18 +195,20 @@ class Photo extends Model
 		$photo['license'] = Configs::get_value('default_license'); // default
 
 		// shutter speed needs to be processed. It is stored as a string `a/b s`
-		if ($photo['shutter'] != '' && substr($photo['shutter'], 0, 2) != '1/' && substr($photo['shutter'], 1, 2) != '/0') {
+		if ($photo['shutter'] != '' && substr($photo['shutter'], 0, 2) != '1/') {
 			preg_match('/(\d+)\/(\d+) s/', $photo['shutter'], $matches);
 			if ($matches) {
 				$a = intval($matches[1]);
 				$b = intval($matches[2]);
-				$gcd = Helpers::gcd($a, $b);
-				$a = $a / $gcd;
-				$b = $b / $gcd;
-				if ($a == 1) {
-					$photo['shutter'] = '1/' . $b . ' s';
-				} else {
-					$photo['shutter'] = ($a / $b) . ' s';
+				if ($b != 0) {
+					$gcd = Helpers::gcd($a, $b);
+					$a = $a / $gcd;
+					$b = $b / $gcd;
+					if ($a == 1) {
+						$photo['shutter'] = '1/' . $b . ' s';
+					} else {
+						$photo['shutter'] = ($a / $b) . ' s';
+					}
 				}
 			}
 		}


### PR DESCRIPTION

    app/Photo.php: fixup invalid shutter data "0/0 s" caused call to Helpers::gcd throws Modulo by zero exception
    
    Helpers::gcd(): check modulo by zero error

in function `prepareData()`:

for some reason, the photo may have invalid `$photo['shutter']` data like:
`"0/0 s"`
thus, caused call to Helpers::gcd throws Modulo by zero exception

