### PR TITLE
Provide option to disable first/last wraparound

### DIFF
--- a/app/ModelFunctions/AlbumFunctions.php
+++ b/app/ModelFunctions/AlbumFunctions.php
@@ -205,7 +205,7 @@ class AlbumFunctions
 			$photo_counter++;
 		}
 
-		if (count($return_photos) > 0) {
+		if (count($return_photos) > 0 && Configs::get_value('photos_wraparound', '1') === '1') {
 			// Enable next and previous for the first and last photo
 			$lastElement = end($return_photos);
 			$lastElementId = $lastElement['id'];

--- a/database/migrations/2019_07_13_214052_photos_wraparound.php
+++ b/database/migrations/2019_07_13_214052_photos_wraparound.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Configs;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class PhotosWraparound extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		if (Schema::hasTable('configs')) {
+			DB::table('configs')->insert([
+				[
+					'key' => 'photos_wraparound',
+					'value' => '1',
+					'confidentiality' => 0,
+				],
+			]);
+		} else {
+			echo "Table configs does not exists\n";
+		}
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		if (env('DB_DROP_CLEAR_TABLES_ON_ROLLBACK', false)) {
+			Configs::where('key', '=', 'photos_wraparound')->delete();
+		}
+	}
+}


### PR DESCRIPTION
Trivial PR providing a configurable option to disable photo wraparound on first/last picture. It's off by default to match the current behavior.

I was actually surprised to find out that this was implemented on the server side rather than in the front end but in the end it made for an easier implementation, so no complaints. :smiley:

Note that this shouldn't go in without https://github.com/LycheeOrg/Lychee-front/pull/130 because some extra code on the front end is needed to gracefully handle missing prev/next.