### PR TITLE
Fix Import from Link

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -133,7 +133,7 @@ class ImportController extends Controller
 				continue;
 			}
 			// Import photo
-			if (!$this->photo($tmp_name, Configs::get_value('delete_imported', '0'), $request['albumID'])) {
+			if (!$this->photo($tmp_name, true, $request['albumID'])) {
 				$error = true;
 				Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $tmp_name . ')');
 				continue;

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -133,7 +133,7 @@ class ImportController extends Controller
 				continue;
 			}
 			// Import photo
-			if (!$this->photo($tmp_name, $request['albumID'])) {
+			if (!$this->photo($tmp_name, Configs::get_value('delete_imported', '0'), $request['albumID'])) {
 				$error = true;
 				Logs::error(__METHOD__, __LINE__, 'Could not import file (' . $tmp_name . ')');
 				continue;

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -308,6 +308,9 @@ class PhotoFunctions
 			}
 		} else {
 			// Photo already exists
+			if ($delete_imported && !is_uploaded_file($tmp_name)) {
+				@unlink($tmp_name);
+			}
 			// Check if the user wants to skip duplicates
 			if (Configs::get()['skip_duplicates'] === '1') {
 				Logs::notice(__METHOD__, __LINE__, 'Skipped upload of existing photo because skipDuplicates is activated');

--- a/app/Photo.php
+++ b/app/Photo.php
@@ -403,7 +403,7 @@ class Photo extends Model
 			}
 
 			// TODO: USE STORAGE FOR DELETE
-			if (Storage::exists('medium/' . $photoName2x) && !unlink(Storage::path('medium/' . $photoName2x))) {
+			if (Storage::exists('small/' . $photoName2x) && !unlink(Storage::path('small/' . $photoName2x))) {
 				Logs::error(__METHOD__, __LINE__, 'Could not delete high-res photo in uploads/small/');
 				$error = true;
 			}


### PR DESCRIPTION
As reported by @d7415, _Import from Link_ stopped respecting the current album. Looks like I'm the one who broke it while working on _Import from Server_. Sorry!

So this trivial patch restores the previous behavior. Here's a question though: shouldn't we _always_ delete the imported file in this particular case? We are the ones who created the file by downloading the picture from the URL before importing it into Lychee. What's the point of keeping it around?