### PR TITLE
Use the source format for small/medium with GD

### DIFF
--- a/app/Image/GdHandler.php
+++ b/app/Image/GdHandler.php
@@ -53,7 +53,20 @@ class GdHandler implements ImageHandlerInterface
 		}
 
 		imagecopyresampled($image, $sourceImg, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
-		imagejpeg($image, $destination, $this->compressionQuality);
+
+		switch ($mime) {
+			case IMAGETYPE_JPEG:
+			case IMAGETYPE_JPEG2000:
+				imagejpeg($image, $destination, $this->compressionQuality);
+				break;
+			case IMAGETYPE_PNG:
+				imagepng($image, $destination);
+				break;
+			case IMAGETYPE_GIF:
+				imagegif($image, $destination);
+				break;
+			// createImage above already checked for any invalid values
+		}
 
 		imagedestroy($image);
 		imagedestroy($sourceImg);

--- a/app/Image/ImagickHandler.php
+++ b/app/Image/ImagickHandler.php
@@ -36,7 +36,6 @@ class ImagickHandler implements ImageHandlerInterface
 			$image = new \Imagick();
 			$image->readImage($source);
 			$image->setImageCompressionQuality($this->compressionQuality);
-			$image->setImageFormat('jpeg');
 
 			// Remove metadata to save some bytes
 			$image->stripImage();
@@ -70,7 +69,6 @@ class ImagickHandler implements ImageHandlerInterface
 			$image = new \Imagick();
 			$image->readImage($source);
 			$image->setImageCompressionQuality($this->compressionQuality);
-			$image->setImageFormat('jpeg');
 
 			// Remove metadata to save some bytes
 			$image->stripImage();


### PR DESCRIPTION
Fixes #375 

* Use the source format for small/medium with GD
* Clean up redundant/confusing calls in Imagick: `setImageFormat` had no effect; the output format is determined by the output file name extension.