### PR TITLE
Pass numbers to the front end as strings

### DIFF
--- a/app/Album.php
+++ b/app/Album.php
@@ -167,12 +167,12 @@ class Album extends Model
 		$album = array();
 
 		// Set unchanged attributes
-		$album['id'] = $this->id;
+		$album['id'] = strval($this->id);
 		$album['title'] = $this->title;
 		$album['public'] = strval($this->public);
 		$album['full_photo'] = $this->full_photo_visible() ? '1' : '0';
 		$album['visible'] = strval($this->visible_hidden);
-		$album['parent_id'] = $this->parent_id;
+		$album['parent_id'] = $this->parent_id !== null ? strval($this->parent_id) : null;
 
 		// Additional attributes
 		// Only part of $album when available

--- a/app/Http/Controllers/AlbumController.php
+++ b/app/Http/Controllers/AlbumController.php
@@ -155,10 +155,10 @@ class AlbumController extends Controller
 		$return['photos'] = $this->albumFunctions->photos($photos_sql, $full_photo);
 
 		$return['id'] = $request['albumID'];
-		$return['num'] = count($return['photos']);
+		$return['num'] = strval(count($return['photos']));
 
 		// finalize the loop
-		if ($return['num'] === 0) {
+		if ($return['num'] === '0') {
 			$return['photos'] = false;
 		}
 

--- a/app/ModelFunctions/AlbumFunctions.php
+++ b/app/ModelFunctions/AlbumFunctions.php
@@ -342,7 +342,7 @@ class AlbumFunctions
 			'thumbs' => array(),
 			'thumbs2x' => array(),
 			'types' => array(),
-			'num' => $photos_sql->count(),
+			'num' => strval($photos_sql->count()),
 		);
 
 		/*

--- a/app/Photo.php
+++ b/app/Photo.php
@@ -170,13 +170,13 @@ class Photo extends Model
 		$photo = array();
 
 		// Set unchanged attributes
-		$photo['id'] = $this->id;
+		$photo['id'] = strval($this->id);
 		$photo['title'] = $this->title;
 		$photo['tags'] = $this->tags;
 		$photo['star'] = $this->star == 1 ? '1' : '0';
-		$photo['album'] = $this->album_id;
-		$photo['width'] = $this->width;
-		$photo['height'] = $this->height;
+		$photo['album'] = $this->album_id !== null ? strval($this->album_id) : null;
+		$photo['width'] = strval($this->width);
+		$photo['height'] = strval($this->height);
 		$photo['type'] = $this->type;
 		$photo['size'] = $this->size;
 		$photo['iso'] = $this->iso;
@@ -324,9 +324,9 @@ class Photo extends Model
 		$photo = array();
 
 		// Set unchanged attributes
-		$photo['id'] = $this->id;
+		$photo['id'] = strval($this->id);
 		$photo['title'] = $this->title;
-		$photo['album'] = $this->album_id;
+		$photo['album'] = $this->album_id !== null ? strval($this->album_id) : null;
 		$photo['latitude'] = $this->latitude;
 		$photo['longitude'] = $this->longitude;
 


### PR DESCRIPTION
Fixes https://github.com/LycheeOrg/Lychee-front/issues/161

The issue there was the identity operator (`===`) resolving to `false` when one side was an integer and the other was a string. It could happen because we were being sloppy on the server side, especially with IDs, sometimes returning them as integers, sometimes as strings. This PR attempts to fix up all such cases that I could find, turning them into strings, which as a bonus should avoid any potential 32-bit issues as well.