### PR TITLE
Fix 382

### DIFF
--- a/app/Http/Controllers/AlbumController.php
+++ b/app/Http/Controllers/AlbumController.php
@@ -881,7 +881,7 @@ class AlbumController extends Controller
 
 		// Set file type and destination
 		$response->headers->set('Content-Type', 'application/x-zip');
-		$disposition = HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $zipTitle . '.zip');
+		$disposition = HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $zipTitle . '.zip', 'Album.zip');
 		$response->headers->set('Content-Disposition', $disposition);
 
 		// Disable caching

--- a/app/Http/Controllers/AlbumController.php
+++ b/app/Http/Controllers/AlbumController.php
@@ -881,7 +881,7 @@ class AlbumController extends Controller
 
 		// Set file type and destination
 		$response->headers->set('Content-Type', 'application/x-zip');
-		$disposition = HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $zipTitle . '.zip', 'Album.zip');
+		$disposition = HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $zipTitle . '.zip', mb_check_encoding($zipTitle, 'ASCII') ? '' : 'Album.zip');
 		$response->headers->set('Content-Disposition', $disposition);
 
 		// Disable caching


### PR DESCRIPTION
Fixes #382 

The fallback name is used only by the browsers that don't support UTF-8 names... It's apparently a messy space but both Firefox and Chrome work fine...