### PR TITLE
Improved fix for #174

### DIFF
--- a/app/Console/Commands/reset_admin.php
+++ b/app/Console/Commands/reset_admin.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Configs;
+use Illuminate\Console\Command;
+
+class reset_admin extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'lychee:reset_admin';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Reset Login and Password of the admin user.';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		Configs::where('key', '=', 'username')->orWhere('key', '=', 'password')->update(['value' => '']);
+	}
+}


### PR DESCRIPTION
Add a `artisan lychee:reset_admin` command.

This erases the bcrypt values for `username` and `password` in the config database, allowing the re-creation of the admin logins. Pictures are not lost, it is just the authentication methods which is reset.