### PR TITLE
fix: add an existing table check when migration tables

### DIFF
--- a/database/migrations/2019_02_21_114356_create_pages_table.php
+++ b/database/migrations/2019_02_21_114356_create_pages_table.php
@@ -15,51 +15,55 @@ class CreatePagesTable extends Migration
 	 */
 	public function up()
 	{
-		Schema::create('pages', function (Blueprint $table) {
-			$table->increments('id');
-			$table->string('title', 150)->default('');
-			$table->string('menu_title', 100)->default('');
-			$table->boolean('in_menu')->default(false);
-			$table->boolean('enabled')->default(false);
-			$table->string('link', 150)->default('');
-			$table->integer('order')->default(0);
-			$table->timestamps();
-		});
+		if (!Schema::hasTable('pages')) {
+			Schema::create('pages', function (Blueprint $table) {
+				$table->increments('id');
+				$table->string('title', 150)->default('');
+				$table->string('menu_title', 100)->default('');
+				$table->boolean('in_menu')->default(false);
+				$table->boolean('enabled')->default(false);
+				$table->string('link', 150)->default('');
+				$table->integer('order')->default(0);
+				$table->timestamps();
+			});
+		}
 
-		DB::table('pages')->insert([
-			//			[
-			//				'title'      => 'contact',
-			//				'menu_title' => 'contact',
-			//				'in_menu'    => true,
-			//				'link'       => '/contact',
-			//				'enabled'    => true,
-			//				'order'      => 0
-			//			],
-			//			[
-			//				'title'      => 'about',
-			//				'menu_title' => 'about',
-			//				'in_menu'    => true,
-			//				'link'       => '/about',
-			//				'enabled'    => true,
-			//				'order'      => 1
-			//			],
-			[
-				'title' => 'gallery',
-				'menu_title' => 'gallery',
-				'in_menu' => true,
-				'link' => '/gallery',
-				'enabled' => true,
-				'order' => 2,
-			],
-			//			[
-			//				'title'      => 'portfolio',
-			//				'menu_title' => 'portfolio',
-			//				'in_menu'    => true,
-			//				'link'       => '/portfolio',
-			//				'enabled'    => true,
-			//				'order'      => 3
-			//			],
-		]);
+		if (!DB::table('pages')->where('title', 'gallery')->exists()) {
+			DB::table('pages')->insert([
+				//			[
+				//				'title'      => 'contact',
+				//				'menu_title' => 'contact',
+				//				'in_menu'    => true,
+				//				'link'       => '/contact',
+				//				'enabled'    => true,
+				//				'order'      => 0
+				//			],
+				//			[
+				//				'title'      => 'about',
+				//				'menu_title' => 'about',
+				//				'in_menu'    => true,
+				//				'link'       => '/about',
+				//				'enabled'    => true,
+				//				'order'      => 1
+				//			],
+				[
+					'title' => 'gallery',
+					'menu_title' => 'gallery',
+					'in_menu' => true,
+					'link' => '/gallery',
+					'enabled' => true,
+					'order' => 2,
+				],
+				//			[
+				//				'title'      => 'portfolio',
+				//				'menu_title' => 'portfolio',
+				//				'in_menu'    => true,
+				//				'link'       => '/portfolio',
+				//				'enabled'    => true,
+				//				'order'      => 3
+				//			],
+			]);
+		}
 	}
 
 	/**

--- a/database/migrations/2019_02_21_114408_create_page_contents_table.php
+++ b/database/migrations/2019_02_21_114408_create_page_contents_table.php
@@ -14,16 +14,18 @@ class CreatePageContentsTable extends Migration
 	 */
 	public function up()
 	{
-		Schema::create('page_contents', function (Blueprint $table) {
-			$table->increments('id');
-			$table->integer('page_id')->unsigned();
-			$table->foreign('page_id')->references('id')->on('pages')->onDelete('cascade');
-			$table->text('content');
-			$table->string('class', 150);
-			$table->enum('type', ['div', 'img']);
-			$table->integer('order')->default(0);
-			$table->timestamps();
-		});
+		if (!Schema::hasTable('page_contents')) {
+			Schema::create('page_contents', function (Blueprint $table) {
+				$table->increments('id');
+				$table->integer('page_id')->unsigned();
+				$table->foreign('page_id')->references('id')->on('pages')->onDelete('cascade');
+				$table->text('content');
+				$table->string('class', 150);
+				$table->enum('type', ['div', 'img']);
+				$table->integer('order')->default(0);
+				$table->timestamps();
+			});
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description

`pages` and `page_contents` tables migration are failed if I do `artisan migrate rollback` once.

## Solution

Added conditional operator to check these tables already exists or not before do migrate these tables.