### PR TITLE
fix update_check_every_days value in DB from 'Config' to 'config'

### DIFF
--- a/database/migrations/2019_12_15_1000_config_check_update_every_cat_fix.php
+++ b/database/migrations/2019_12_15_1000_config_check_update_every_cat_fix.php
@@ -1,0 +1,32 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+use App\Configs;
+use Illuminate\Database\Migrations\Migration;
+
+class ConfigCheckUpdateEveryCatFix extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		if (Configs::where('key', 'update_check_every_days')->exists()) {
+			Configs::where('key', 'update_check_every_days')->update(['cat' => 'config']);
+		}
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		if (env('DB_DROP_CLEAR_TABLES_ON_ROLLBACK', false)) {
+			Configs::where('key', 'update_check_every_days')->update(['cat' => 'Config']);
+		}
+	}
+}


### PR DESCRIPTION
## Description

Current configuration definition value in DB (`configs.cat`) has two values `config` and `Config`.

In 'Full Settings' appear two 'Config' sections caused by this diff.

![config-gui](https://user-images.githubusercontent.com/11273093/70856881-c951fa80-1f27-11ea-9634-0b6e6de4c0ab.jpg)

## Fix

Update `Config` to `config` for `update_check_every_days`.

![after2](https://user-images.githubusercontent.com/11273093/70856887-d7078000-1f27-11ea-94d1-2fa947608105.jpg)

Thank you.