### PR TITLE
support cache busting feature for JavaScript and CSS

### DIFF
--- a/app/Assets/Helpers.php
+++ b/app/Assets/Helpers.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Assets;
+
+use Illuminate\Support\Facades\File;
+
+class Helpers
+{
+	/**
+	 * Add UnixTimeStamp to file path suffix.
+	 *
+	 * @param string $filePath
+	 *
+	 * @return string
+	 */
+	public static function cacheBusting(string $filePath): string
+	{
+		if (File::exists($filePath)) {
+			$unixTimeStamp = File::lastModified($filePath);
+
+			return "{$filePath}?{$unixTimeStamp}";
+		}
+
+		return $filePath;
+	}
+}
+

--- a/resources/views/frame.blade.php
+++ b/resources/views/frame.blade.php
@@ -5,7 +5,7 @@
 @endsection
 
 @section('head-css')
-    <link type="text/css" rel="stylesheet" href="dist/frame.css">
+    <link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/frame.css') }}">
 @endsection
 
 

--- a/resources/views/gallery.blade.php
+++ b/resources/views/gallery.blade.php
@@ -4,8 +4,8 @@
 @endsection
 
 @section('head-css')
-<link type="text/css" rel="stylesheet" href="dist/main.css">
-<link type="text/css" rel="stylesheet" href="dist/user.css">
+<link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/main.css') }}">
+<link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/user.css') }}">
 @endsection
 
 @section('content')
@@ -181,7 +181,7 @@
 </div>
 
 <!-- JS -->
-<script async type="text/javascript" src="dist/main.js"></script>
+<script async type="text/javascript" src="{{ App\Assets\Helpers::cacheBusting('dist/main.js') }}"></script>
 </div>
 
 @include('includes.footer')

--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -1,12 +1,12 @@
 @extends('layouts.simple')
 
 @section('head-js')
-    <script type="text/javascript" src="dist/landing.js"></script>
+    <script type="text/javascript" src="{{ App\Assets\Helpers::cacheBusting('dist/landing.js') }}"></script>
 @endsection
 
 @section('head-css')
-    <link type="text/css" rel="stylesheet" href="dist/landing.css">
-    <link type="text/css" rel="stylesheet" href="dist/user.css">
+    <link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/landing.css') }}">
+    <link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/user.css') }}">
 @endsection
 
 @section('content')

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -1,12 +1,12 @@
 @extends('layouts.simple')
 
 @section('head-js')
-    <script type="text/javascript" src="dist/landing.js"></script>
+    <script type="text/javascript" src="{{ App\Assets\Helpers::cacheBusting('dist/landing.js') }}"></script>
 @endsection
 
 @section('head-css')
-    <link type="text/css" rel="stylesheet" href="dist/page.css">
-	<link type="text/css" rel="stylesheet" href="dist/user.css">
+    <link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/page.css') }}">
+	<link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/user.css') }}">
 @endsection
 
 @section('content')

--- a/resources/views/view.blade.php
+++ b/resources/views/view.blade.php
@@ -2,7 +2,7 @@
 
 @section('head-css')
     <!-- CSS -->
-    <link type="text/css" rel="stylesheet" href="dist/main.css">
+    <link type="text/css" rel="stylesheet" href="{{ App\Assets\Helpers::cacheBusting('dist/main.css') }}">
 
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="apple-touch-icon" href="Lychee-front/images/apple-touch-icon-iphone.png" sizes="120x120">
@@ -64,7 +64,7 @@
 </div>
 
 <!-- JS -->
-<script type="text/javascript" src="dist/view.js"></script>
+<script type="text/javascript" src="{{ App\Assets\Helpers::cacheBusting('dist/view.js') }}"></script>
 
 <script type="text/javascript">
 lychee.api_V2 = true;


### PR DESCRIPTION
## Description

If `js` of `css` updated user has to clear their browser cache.
Or webserver owner has to configure their web server's cache settings just like #305 .

This PR adds UnixTimeStamp suffix to `js` and `css` just like `main.js?1576386855`

## Implementation

* Created `Assets\Helpers` class. And add `static function` it name is `cacheBusting`.
    * This function require `filePath`.
    * If file exists return `filePath` with UnixTimeStamp.
    * If file does not exist return `filePath` without change.
* Wrap `js` and `css` in `*.blade.php` with `cacheBusting` function.

## Question

* Is test needed? Which directory should I add UnitTest?

## Screenshot

JavaScript with UnixTimeStamp

![jstimestamp](https://user-images.githubusercontent.com/11273093/70858552-5193c800-1f47-11ea-942b-b45e717f7058.jpg)

CSS with UnixTimeStamp

![csstimestamp](https://user-images.githubusercontent.com/11273093/70858553-5193c800-1f47-11ea-9bbd-a468a3cb193e.jpg)