### PR TITLE
Fix issue 409 (has_exiftool=null in database)

### DIFF
--- a/app/Configs.php
+++ b/app/Configs.php
@@ -150,6 +150,9 @@ class Configs extends Model
 	 */
 	public static function get_value(string $key, $default = null)
 	{
+		// These config values are allowed to be empty/null
+		$whitelist_keys_nullable = ['has_exiftool'];
+
 		if (!self::$cache) {
 			/*
 			 * try is here because when composer does the package discovery it
@@ -169,10 +172,12 @@ class Configs extends Model
 			/*
 			 * For some reason the $default is not returned above...
 			 */
-			try {
-				Logs::error(__METHOD__, __LINE__, $key . ' does not exist in config (local) !');
-			} catch (Exception $e) {
-				// yeah we do nothing because we cannot do anything in that case ...  :p
+			if (!in_array($key, $whitelist_keys_nullable)) {
+				try {
+					Logs::error(__METHOD__, __LINE__, $key . ' does not exist in config (local) !');
+				} catch (Exception $e) {
+					// yeah we do nothing because we cannot do anything in that case ...  :p
+				}
 			}
 
 			return $default;


### PR DESCRIPTION
Issue #409 is caused by config parameter has_exiftool being null in the database and a later check afterwards if all config parameters are not-null. But, has_exiftool is using a 3-way logic: null = no test if exiftool available done so far; true = exiftool is available; false = not available.

Solution: Add a whitelisting feature for the check of config parameters required to be not-null.

