### PR TITLE
Updated type of has_exiftool to ternary

### DIFF
--- a/app/Configs.php
+++ b/app/Configs.php
@@ -150,9 +150,6 @@ class Configs extends Model
 	 */
 	public static function get_value(string $key, $default = null)
 	{
-		// These config values are allowed to be empty/null
-		$whitelist_keys_nullable = ['has_exiftool'];
-
 		if (!self::$cache) {
 			/*
 			 * try is here because when composer does the package discovery it
@@ -172,12 +169,10 @@ class Configs extends Model
 			/*
 			 * For some reason the $default is not returned above...
 			 */
-			if (!in_array($key, $whitelist_keys_nullable)) {
-				try {
-					Logs::error(__METHOD__, __LINE__, $key . ' does not exist in config (local) !');
-				} catch (Exception $e) {
-					// yeah we do nothing because we cannot do anything in that case ...  :p
-				}
+			try {
+				Logs::error(__METHOD__, __LINE__, $key . ' does not exist in config (local) !');
+			} catch (Exception $e) {
+				// yeah we do nothing because we cannot do anything in that case ...  :p
 			}
 
 			return $default;
@@ -255,21 +250,29 @@ class Configs extends Model
 	 */
 	public static function hasExiftool()
 	{
+		// has_exiftool has the following values:
+		// 0: No Exiftool
+		// 1: Exiftool is available
+		// 2: Not yet tested if exiftool is available
+
 		$has_exiftool = self::get_value('has_exiftool');
+
 		// value not yet set -> let's see if exiftool is available
-		if ($has_exiftool === null) {
+		if ($has_exiftool == 2) {
 			$status = 0;
 			$output = '';
 			exec('which exiftool 2>&1 > /dev/null', $output, $status);
 			if ($status != 0) {
-				self::set('has_exiftool', false);
+				self::set('has_exiftool', 0);
 				$has_exiftool = false;
 			} else {
-				self::set('has_exiftool', true);
+				self::set('has_exiftool', 1);
 				$has_exiftool = true;
 			}
+		} elseif ($has_exiftool == 1) {
+			$has_exiftool = true;
 		} else {
-			$has_exiftool = self::get_value('has_exiftool');
+			$has_exiftool = false;
 		}
 
 		return $has_exiftool;

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -71,12 +71,15 @@ class Extractor
 	{
 		$reader = null;
 
-		if (Configs::hasExiftool() == true) {
-			// reader with Exiftool adapter
-			$reader = Reader::factory(Reader::TYPE_EXIFTOOL);
-		} elseif (strpos($type, 'video') !== 0) {
-			// It's a photo -> Use Php native tools
-			$reader = Reader::factory(Reader::TYPE_NATIVE);
+		if (strpos($type, 'video') !== 0) {
+			// It's a photo
+			if (Configs::hasExiftool() == true) {
+				// reader with Exiftool adapter
+				$reader = Reader::factory(Reader::TYPE_EXIFTOOL);
+			} elseif (strpos($type, 'video') !== 0) {
+				// Use Php native tools
+				$reader = Reader::factory(Reader::TYPE_NATIVE);
+			}
 		} else {
 			// It's a video -> use FFProbe
 			$reader = Reader::factory(Reader::TYPE_FFPROBE);

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -47,9 +47,12 @@ class PhotoFunctions
 	 */
 	public $validVideoTypes = [
 		'video/mp4',
+		'video/mpeg',
 		'video/ogg',
 		'video/webm',
 		'video/quicktime',
+		'video/x-ms-asf', // wmv file
+		'video/x-msvideo', // Avi
 	];
 
 	/**
@@ -62,8 +65,11 @@ class PhotoFunctions
 		'.gif',
 		'.ogv',
 		'.mp4',
+		'.mpg',
 		'.webm',
 		'.mov',
+		'.avi',
+		'.wmv',
 	];
 
 	/**

--- a/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
+++ b/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
@@ -21,11 +21,26 @@ class ConfigExiftoolTernary extends Migration
 			define('TERNARY', '0|1|2');
 		}
 
+		// Let's run the check for exiftool right here
+		$status = 0;
+		$output = '';
+		$has_exiftool = 2; // not set
+		try {
+			exec('which exiftool 2>&1 > /dev/null', $output, $status);
+			if ($status != 0) {
+				$has_exiftool = 0; // false
+			} else {
+				$has_exiftool = 1; // true
+			}
+		} catch (\Exception $e) {
+			// let's do nothing
+		}
+
 		if (Schema::hasTable('configs')) {
 			Configs::where('key', '=', 'has_exiftool')
 			  ->update(
 				[
-					'value' => 2,
+					'value' => $has_exiftool,
 					'type_range' => TERNARY,
 				]);
 		} else {

--- a/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
+++ b/database/migrations/2019_12_25_0600_config_exiftool_ternary.php
@@ -1,0 +1,55 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+use App\Configs;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class ConfigExiftoolTernary extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		if (!defined('BOOL')) {
+			define('BOOL', '0|1');
+		}
+		if (!defined('TERNARY')) {
+			define('TERNARY', '0|1|2');
+		}
+
+		if (Schema::hasTable('configs')) {
+			Configs::where('key', '=', 'has_exiftool')
+			  ->update(
+				[
+					'value' => 2,
+					'type_range' => TERNARY,
+				]);
+		} else {
+			echo "Table configs does not exists\n";
+		}
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		if (!defined('BOOL')) {
+			define('BOOL', '0|1');
+		}
+		if (env('DB_DROP_CLEAR_TABLES_ON_ROLLBACK', false)) {
+			Configs::where('key', '=', 'has_exiftool')
+				->update(
+				[
+					'value' => null,
+					'type_range' => BOOL,
+				]);
+		}
+	}
+}


### PR DESCRIPTION
#409 has been fixed by #411 by whitelisting sanity checks for getting config values (setting still caused an error). This PR now removed again the whitelisting and introduces a proper solution changing type of has_exiftool to ternary (0,1,2).

The config variable has_exiftool was implemented as a bool and null was used in cases, test for exiftool has not yet been performed. This causes issues during sanity checks (getting config values and setting config values).

Solution: Move to ternary with the following values:
0 = Exiftool not available
1 = Exiftool is available
2 = Not yet tested