### PR TITLE
imagick: keep ICC profile when crop and scale image

### DIFF
--- a/app/Image/ImagickHandler.php
+++ b/app/Image/ImagickHandler.php
@@ -37,8 +37,14 @@ class ImagickHandler implements ImageHandlerInterface
 			$image->readImage($source);
 			$image->setImageCompressionQuality($this->compressionQuality);
 
+			$profiles = $image->getImageProfiles("icc", true);
+
 			// Remove metadata to save some bytes
 			$image->stripImage();
+
+			if(!empty($profiles)) {
+				$image->profileImage("icc", $profiles['icc']);
+			}
 
 			$image->scaleImage($newWidth, $newHeight, ($newWidth != 0 && $newHeight != 0));
 			$image->writeImage($destination);
@@ -70,8 +76,14 @@ class ImagickHandler implements ImageHandlerInterface
 			$image->readImage($source);
 			$image->setImageCompressionQuality($this->compressionQuality);
 
+			$profiles = $image->getImageProfiles("icc", true);
+
 			// Remove metadata to save some bytes
 			$image->stripImage();
+
+			if(!empty($profiles)) {
+				$image->profileImage("icc", $profiles['icc']);
+			}
 
 			$image->cropThumbnailImage($newWidth, $newHeight);
 			$image->writeImage($destination);

--- a/app/Image/ImagickHandler.php
+++ b/app/Image/ImagickHandler.php
@@ -37,13 +37,13 @@ class ImagickHandler implements ImageHandlerInterface
 			$image->readImage($source);
 			$image->setImageCompressionQuality($this->compressionQuality);
 
-			$profiles = $image->getImageProfiles("icc", true);
+			$profiles = $image->getImageProfiles('icc', true);
 
 			// Remove metadata to save some bytes
 			$image->stripImage();
 
-			if(!empty($profiles)) {
-				$image->profileImage("icc", $profiles['icc']);
+			if (!empty($profiles)) {
+				$image->profileImage('icc', $profiles['icc']);
 			}
 
 			$image->scaleImage($newWidth, $newHeight, ($newWidth != 0 && $newHeight != 0));
@@ -76,13 +76,13 @@ class ImagickHandler implements ImageHandlerInterface
 			$image->readImage($source);
 			$image->setImageCompressionQuality($this->compressionQuality);
 
-			$profiles = $image->getImageProfiles("icc", true);
+			$profiles = $image->getImageProfiles('icc', true);
 
 			// Remove metadata to save some bytes
 			$image->stripImage();
 
-			if(!empty($profiles)) {
-				$image->profileImage("icc", $profiles['icc']);
+			if (!empty($profiles)) {
+				$image->profileImage('icc', $profiles['icc']);
 			}
 
 			$image->cropThumbnailImage($newWidth, $newHeight);


### PR DESCRIPTION
Hi :)

## Description

I'm using `Adobe Lightroom CC`. I extract JPEG from RAW and that ICC is `ProPhoto RGB`.
I notice a thumbnail color looks like dull than the original.

According to an investigation, this phenomenon occurs when ICC is not `sRGB`

Please see the following. [live data (before fix) is here](https://photo.yoshinorin.net/#15773762048402).

![thumbs](https://user-images.githubusercontent.com/11273093/71503099-24380a00-28b7-11ea-9ec8-ce667ecc2cbd.jpg)

## Cause

Imagick `stripImage` function remove all meta info.

> https://github.com/LycheeOrg/Lychee-Laravel/blob/362f85e964382616f469b96c3cdfd8c473875db1/app/Image/ImagickHandler.php#L40-L41

## Solution

I found a solution from Imagick document.

> https://www.php.net/manual/en/imagick.stripimage.php

1. Extract the ICC profile
2. Strip EXIF data and image profile
3. Add the ICC profile back

## File size

I compared the thumbnail file size before and after.

* Before: 186KB
* After: 187KB

I expected the thumbnail file size will be more big...
I didn't test other images. So, I'm not sure if the thumbnail file size is no-problem for other images...

## Others

It seems GD has the same issue, but I can't find a solution for GD.

> https://bugs.php.net/bug.php?id=53598
> https://github.com/libgd/libgd/issues/136

Thank you :)