### PR TITLE
fixes #410

### DIFF
--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -339,9 +339,9 @@ class PhotoFunctions
 
 		// Use title of file if IPTC title missing
 		if ($kind == 'raw') {
-			$info['title'] = substr(basename($file['name']), 0, 30);
+			$info['title'] = substr(basename($file['name']), 0, 98);
 		} elseif ($info['title'] === '') {
-			$info['title'] = substr(basename($file['name'], $extension), 0, 30);
+			$info['title'] = substr(basename($file['name'], $extension), 0, 98);
 		}
 
 		$photo->title = $info['title'];


### PR DESCRIPTION
the database field is of type `$table->string('title', 100);`
So we extend the length of possible titles to 98 characters instead of 30.