### PR TITLE
Format framerate to have only 2 decimal digits

### DIFF
--- a/app/Photo.php
+++ b/app/Photo.php
@@ -270,6 +270,9 @@ class Photo extends Model
 		// if this is a video
 		if (strpos($this->type, 'video') === 0) {
 			$photoUrl = $this->thumbUrl;
+
+			// We need to format the framerate (stored as focal) -> max 2 decimal digits
+			$photo['focal'] = round($photo['focal'], 2);
 		} else {
 			$photoUrl = $this->url;
 		}


### PR DESCRIPTION
The framerate was delivered to frontend in its full beauty, potentially with a lot of decimal digits -> we truncate it at 2 decimal digits by rounding