### PR TITLE
Improve video handling in case of no ffmpeg

### DIFF
--- a/app/Configs.php
+++ b/app/Configs.php
@@ -278,6 +278,40 @@ class Configs extends Model
 		return $has_exiftool;
 	}
 
+
+	/**
+	 * @return bool returns the Exiftool setting
+	 */
+	public static function hasFFmpeg()
+	{
+		// has_ffmpeg has the following values:
+		// 0: No FFmpeg
+		// 1: FFmpeg is available
+		// 2: Not yet tested if FFmpeg is available
+
+		$has_ffmpeg = self::get_value('has_ffmpeg');
+
+		// value not yet set -> let's see if FFmpeg is available
+		if ($has_ffmpeg == 2) {
+			$status = 0;
+			$output = '';
+			exec('which FFmpeg 2>&1 > /dev/null', $output, $status);
+			if ($status != 0) {
+				self::set('has_ffmpeg', 0);
+				$has_ffmpeg = false;
+			} else {
+				self::set('has_ffmpeg', 1);
+				$has_ffmpeg = true;
+			}
+		} elseif ($has_ffmpeg == 1) {
+			$has_ffmpeg = true;
+		} else {
+			$has_ffmpeg = false;
+		}
+
+		return $has_ffmpeg;
+	}
+
 	/**
 	 * Define scopes.
 	 */

--- a/app/Configs.php
+++ b/app/Configs.php
@@ -278,7 +278,6 @@ class Configs extends Model
 		return $has_exiftool;
 	}
 
-
 	/**
 	 * @return bool returns the Exiftool setting
 	 */

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -84,15 +84,16 @@ class Extractor
 		} else {
 			// Let's try to use FFmpeg; if not available, let's try Exiftool
 			if (Configs::hasFFmpeg() == true) {
-			    // It's a video -> use FFProbe
-		    	$reader = Reader::factory(Reader::TYPE_FFPROBE);
-			} else if (Configs::hasExiftool() == true) {
-				  // reader with Exiftool adapter
-				  $reader = Reader::factory(Reader::TYPE_EXIFTOOL);
+				// It's a video -> use FFProbe
+				$reader = Reader::factory(Reader::TYPE_FFPROBE);
+			} elseif (Configs::hasExiftool() == true) {
+				// reader with Exiftool adapter
+				$reader = Reader::factory(Reader::TYPE_EXIFTOOL);
 			} else {
-				  // Use Php native tools to extract at least MimeType and Filesize
-					// For all other properties, it will not return anything
-				  $reader = Reader::factory(Reader::TYPE_NATIVE);
+				// Use Php native tools to extract at least MimeType and Filesize
+				// For all other properties, it will not return anything
+				$reader = Reader::factory(Reader::TYPE_NATIVE);
+				Logs::notice(__METHOD__, __LINE__, 'FFmpeg and Exiftool not being available; Extraction of metadata limited to mime type and file size.');
 			}
 		}
 

--- a/app/Metadata/Extractor.php
+++ b/app/Metadata/Extractor.php
@@ -82,8 +82,18 @@ class Extractor
 				$reader = Reader::factory(Reader::TYPE_NATIVE);
 			}
 		} else {
-			// It's a video -> use FFProbe
-			$reader = Reader::factory(Reader::TYPE_FFPROBE);
+			// Let's try to use FFmpeg; if not available, let's try Exiftool
+			if (Configs::hasFFmpeg() == true) {
+			    // It's a video -> use FFProbe
+		    	$reader = Reader::factory(Reader::TYPE_FFPROBE);
+			} else if (Configs::hasExiftool() == true) {
+				  // reader with Exiftool adapter
+				  $reader = Reader::factory(Reader::TYPE_EXIFTOOL);
+			} else {
+				  // Use Php native tools to extract at least MimeType and Filesize
+					// For all other properties, it will not return anything
+				  $reader = Reader::factory(Reader::TYPE_NATIVE);
+			}
 		}
 
 		$exif = $reader->read($filename);

--- a/database/migrations/2020_01_04_1200_config_has_ffmpeg.php
+++ b/database/migrations/2020_01_04_1200_config_has_ffmpeg.php
@@ -1,0 +1,65 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+use App\Configs;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class ConfigHasFFmpeg extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		if (!defined('BOOL')) {
+			define('BOOL', '0|1');
+		}
+		if (!defined('TERNARY')) {
+			define('TERNARY', '0|1|2');
+		}
+
+		// Let's run the check for exiftool right here
+		$status = 0;
+		$output = '';
+		$has_ffmpeg = 2; // not set
+		try {
+			exec('which ffmpeg 2>&1 > /dev/null', $output, $status);
+			if ($status != 0) {
+				$has_ffmpeg = 0; // false
+			} else {
+				$has_ffmpeg = 1; // true
+			}
+		} catch (\Exception $e) {
+			// let's do nothing
+		}
+
+		if (Schema::hasTable('configs')) {
+			DB::table('configs')->insert([
+				[
+					'key' => 'has_ffmpeg',
+					'value' => $has_ffmpeg,
+					'confidentiality' => 2,
+					'cat' => 'Image Processing',
+					'type_range' => TERNARY,
+				],
+			]);
+		} else {
+			echo "Table configs does not exists\n";
+		}
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		if (env('DB_DROP_CLEAR_TABLES_ON_ROLLBACK', false)) {
+			Configs::where('key', '=', 'has_ffmpeg')->delete();
+		}
+	}
+}


### PR DESCRIPTION
Video upload failed in case ffmpeg was not installed.

* Added config field has_ffmpeg (0 = no ffmpeg; 1 = ffmpeg available; 2 = not tested)
* Metadata extraction first trys ffmpeg, then exiftool and uses php native tools as fallback (which only extracts mime type and filesize)