### PR TITLE
Add try-catch to function autorotate for Imagick

### DIFF
--- a/app/Image/ImagickHandler.php
+++ b/app/Image/ImagickHandler.php
@@ -158,7 +158,7 @@ class ImagickHandler implements ImageHandlerInterface
 		} catch (ImagickException $exception) {
 			Logs::error(__METHOD__, __LINE__, $exception->getMessage());
 
-			return array(false, false);
+			return [false, false];
 		}
 	}
 }

--- a/app/Image/ImagickHandler.php
+++ b/app/Image/ImagickHandler.php
@@ -104,55 +104,61 @@ class ImagickHandler implements ImageHandlerInterface
 	 */
 	public function autoRotate(string $path, array $info): array
 	{
-		$image = new \Imagick();
-		$image->readImage($path);
+		try {
+			$image = new \Imagick();
+			$image->readImage($path);
 
-		$orientation = $image->getImageOrientation();
+			$orientation = $image->getImageOrientation();
 
-		$rotate = true;
-		switch ($orientation) {
-			case \Imagick::ORIENTATION_TOPLEFT:
-				$rotate = false;
-				break;
-			case \Imagick::ORIENTATION_TOPRIGHT:
-				$image->flopImage();
-				break;
-			case \Imagick::ORIENTATION_BOTTOMRIGHT:
-				$image->rotateImage(new \ImagickPixel(), 180);
-				break;
-			case \Imagick::ORIENTATION_BOTTOMLEFT:
-				$image->flopImage();
-				$image->rotateImage(new \ImagickPixel(), 180);
-				break;
-			case \Imagick::ORIENTATION_LEFTTOP:
-				$image->flopImage();
-				$image->rotateImage(new \ImagickPixel(), -90);
-				break;
-			case \Imagick::ORIENTATION_RIGHTTOP:
-				$image->rotateImage(new \ImagickPixel(), 90);
-				break;
-			case \Imagick::ORIENTATION_RIGHTBOTTOM:
-				$image->flopImage();
-				$image->rotateImage(new \ImagickPixel(), 90);
-				break;
-			case \Imagick::ORIENTATION_LEFTBOTTOM:
-				$image->rotateImage(new \ImagickPixel(), -90);
-				break;
+			$rotate = true;
+			switch ($orientation) {
+					case \Imagick::ORIENTATION_TOPLEFT:
+						$rotate = false;
+						break;
+					case \Imagick::ORIENTATION_TOPRIGHT:
+						$image->flopImage();
+						break;
+					case \Imagick::ORIENTATION_BOTTOMRIGHT:
+						$image->rotateImage(new \ImagickPixel(), 180);
+						break;
+					case \Imagick::ORIENTATION_BOTTOMLEFT:
+						$image->flopImage();
+						$image->rotateImage(new \ImagickPixel(), 180);
+						break;
+					case \Imagick::ORIENTATION_LEFTTOP:
+						$image->flopImage();
+						$image->rotateImage(new \ImagickPixel(), -90);
+						break;
+					case \Imagick::ORIENTATION_RIGHTTOP:
+						$image->rotateImage(new \ImagickPixel(), 90);
+						break;
+					case \Imagick::ORIENTATION_RIGHTBOTTOM:
+						$image->flopImage();
+						$image->rotateImage(new \ImagickPixel(), 90);
+						break;
+					case \Imagick::ORIENTATION_LEFTBOTTOM:
+						$image->rotateImage(new \ImagickPixel(), -90);
+						break;
+				}
+
+			if ($rotate) { // we only write if there is a need. Fixes #111
+				$image->setImageOrientation(\Imagick::ORIENTATION_TOPLEFT);
+				$image->writeImage($path);
+			}
+
+			$dimensions = [
+				'width' => $image->getImageWidth(),
+				'height' => $image->getImageHeight(),
+			];
+
+			$image->clear();
+			$image->destroy();
+
+			return $dimensions;
+		} catch (ImagickException $exception) {
+			Logs::error(__METHOD__, __LINE__, $exception->getMessage());
+
+			return array(false, false);
 		}
-
-		if ($rotate) { // we only write if there is a need. Fixes #111
-			$image->setImageOrientation(\Imagick::ORIENTATION_TOPLEFT);
-			$image->writeImage($path);
-		}
-
-		$dimensions = [
-			'width' => $image->getImageWidth(),
-			'height' => $image->getImageHeight(),
-		];
-
-		$image->clear();
-		$image->destroy();
-
-		return $dimensions;
 	}
 }

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -418,7 +418,7 @@ class PhotoFunctions
 				if ($photo->type === 'image/jpeg' && isset($info['orientation']) && $info['orientation'] !== '') {
 					$rotation = $this->imageHandler->autoRotate($path, $info);
 
-					if ($rotation !== array(false, false)) {
+					if ($rotation !== [false, false]) {
 						$photo->width = $rotation['width'];
 						$photo->height = $rotation['height'];
 					}

--- a/app/ModelFunctions/PhotoFunctions.php
+++ b/app/ModelFunctions/PhotoFunctions.php
@@ -418,8 +418,10 @@ class PhotoFunctions
 				if ($photo->type === 'image/jpeg' && isset($info['orientation']) && $info['orientation'] !== '') {
 					$rotation = $this->imageHandler->autoRotate($path, $info);
 
-					$photo->width = $rotation['width'];
-					$photo->height = $rotation['height'];
+					if ($rotation !== array(false, false)) {
+						$photo->width = $rotation['width'];
+						$photo->height = $rotation['height'];
+					}
 				}
 
 				// Set original date


### PR DESCRIPTION
Image handling in function autorate can fail as all other functions using Imagick (e.g. width or height exceeding limits)

We should use try-catch to catch the error (issue when importing via CLI)