### PR TITLE
removing php7.2 support, moving to bionic (18.4) instead of xenial (16.4)'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 os:
   - linux
 
-dist: xenial
+dist: bionic
 
 language: php
 
 php:
-  - '7.2'
   - '7.3'
-  - '7.4snapshot'
+  - '7.4'
 #  - nightly
 env:
   - TRAVIS_COMPOSER_DEV=yes

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": "^7.2.0",
+        "php": "^7.3.0",
         "ext-exif": "*",
         "ext-gd": "*",
         "ext-json": "*",

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Lychee is a free photo-management tool, which runs on your server or web-space. 
 ## Installation
 
 
-To run Lychee, everything you need is a web-server with PHP 7.1 or later and a MySQL-Database. Follow the instructions to install Lychee on your server. This version of Lychee is built on the Laravel framework. To install:
+To run Lychee, everything you need is a web-server with PHP 7.3 or later and a MySQL-Database. Follow the instructions to install Lychee on your server. This version of Lychee is built on the Laravel framework. To install:
 
 1. Clone this repo to your server and set the web root to `lychee-laravel/public`
 2. Run `composer install --no-dev` to install dependencies


### PR DESCRIPTION
https://www.php.net/supported-versions.php

7.2 is end of life, Security fixes only. It will be completely unsupported by 30 Nov 2020

By switching from Xenial to Bionic, I hope to get some speed on the already installed php versions.
