### PR TITLE
Unhide SL options and raw_formats in Diagnostics.

### DIFF
--- a/database/migrations/2020_03_17_200000_unhide_configs.php
+++ b/database/migrations/2020_03_17_200000_unhide_configs.php
@@ -1,0 +1,40 @@
+<?php
+
+/** @noinspection PhpUndefinedClassInspection */
+use App\Configs;
+use Illuminate\Database\Migrations\Migration;
+
+class UnhideConfigs extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		if (Configs::where('key', 'SL_enable')->exists()) {
+			Configs::where('key', 'SL_enable')->update(['confidentiality' => '2']);
+		}
+		if (Configs::where('key', 'SL_for_admin')->exists()) {
+			Configs::where('key', 'SL_for_admin')->update(['confidentiality' => '2']);
+		}
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		if (env('DB_DROP_CLEAR_TABLES_ON_ROLLBACK', false)) {
+			if (Configs::where('key', 'SL_enable')->exists()) {
+				Configs::where('key', 'SL_enable')->update(['confidentiality' => '0']);
+			}
+			if (Configs::where('key', 'SL_for_admin')->exists()) {
+				Configs::where('key', 'SL_for_admin')->update(['confidentiality' => '0']);
+			}
+		}
+	}
+}


### PR DESCRIPTION
I'm not clear on why the SL options were hidden. If nothing else they're very useful for diagnosing issues here. I'm similarly unsure why `raw_formats` was hidden, but I feel less strongly about it being shown.

For once I have actually tested this.